### PR TITLE
Fix #47

### DIFF
--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -87,10 +87,12 @@ class PDFWrapper extends LaravelPDF
     {
         $this->setLocale();
 
-        return Twig::parse(
+        $html = Twig::parse(
             $layout->content_html,
             $this->layoutData($layout, $mergeData)
         );
+
+        return preg_replace('/>\s+</', '><', $html);
     }
 
     /**


### PR DESCRIPTION
Today I got this error after many years of using without any problem:

`No block-level parent found. Not good.`

Funny is, that this problem is appearing only on the development machine and on production is everything fine.

So I found that there could be a problem with empty spaces between tags: https://github.com/barryvdh/laravel-dompdf/issues/389

And this is the quick fix :-) It keeps original content without changes, only remove spaces between tags.
