### PR TITLE
Use Backend URI Config Value for Tests

### DIFF
--- a/tests/controllers/ControllerTestCase.php
+++ b/tests/controllers/ControllerTestCase.php
@@ -20,6 +20,11 @@ class ControllerTestCase extends TestCase
     protected $user;
 
     /**
+     * @var
+     */
+    public $backendUri;
+
+    /**
      * @return void
      */
     public function setUp()
@@ -29,6 +34,8 @@ class ControllerTestCase extends TestCase
         $this->registerFormWidgets();
 
         $this->loginUser();
+
+        $this->backendUri = config('cms.backendUri', 'backend');
     }
 
     /**

--- a/tests/controllers/LayoutsTest.php
+++ b/tests/controllers/LayoutsTest.php
@@ -16,7 +16,7 @@ class LayoutsTest extends ControllerTestCase
     {
         $layout = factory(Layout::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/layouts')
+        $this->get($this->backendUri . '/renatio/dynamicpdf/layouts')
             ->assertSee($layout->name)
             ->assertSuccessful();
     }
@@ -24,7 +24,7 @@ class LayoutsTest extends ControllerTestCase
     /** @test */
     public function it_displays_create_layout_page()
     {
-        $this->get('backend/renatio/dynamicpdf/layouts/create')
+        $this->get($this->backendUri . '/renatio/dynamicpdf/layouts/create')
             ->assertSuccessful();
     }
 
@@ -33,7 +33,7 @@ class LayoutsTest extends ControllerTestCase
     {
         $layout = factory(Layout::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/layouts/update/' . $layout->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/layouts/update/' . $layout->id)
             ->assertSuccessful();
     }
 
@@ -42,7 +42,7 @@ class LayoutsTest extends ControllerTestCase
     {
         $layout = factory(Layout::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/layouts/previewpdf/' . $layout->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/layouts/previewpdf/' . $layout->id)
             ->assertHeader('content-type', 'application/pdf')
             ->assertSuccessful();
     }
@@ -52,7 +52,7 @@ class LayoutsTest extends ControllerTestCase
     {
         $layout = factory(Layout::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/layouts/preview/' . $layout->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/layouts/preview/' . $layout->id)
             ->assertSuccessful();
     }
 

--- a/tests/controllers/TemplatesTest.php
+++ b/tests/controllers/TemplatesTest.php
@@ -16,7 +16,7 @@ class TemplatesTest extends ControllerTestCase
     {
         $template = factory(Template::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/templates')
+        $this->get($this->backendUri . '/renatio/dynamicpdf/templates')
             ->assertSee($template->title)
             ->assertSuccessful();
     }
@@ -24,7 +24,7 @@ class TemplatesTest extends ControllerTestCase
     /** @test */
     public function it_displays_create_template_page()
     {
-        $this->get('backend/renatio/dynamicpdf/templates/create')
+        $this->get($this->backendUri . '/renatio/dynamicpdf/templates/create')
             ->assertSuccessful();
     }
 
@@ -33,7 +33,7 @@ class TemplatesTest extends ControllerTestCase
     {
         $template = factory(Template::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/templates/update/' . $template->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/templates/update/' . $template->id)
             ->assertSuccessful();
     }
 
@@ -42,7 +42,7 @@ class TemplatesTest extends ControllerTestCase
     {
         $template = factory(Template::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/templates/previewpdf/' . $template->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/templates/previewpdf/' . $template->id)
             ->assertHeader('content-type', 'application/pdf')
             ->assertSuccessful();
     }
@@ -52,7 +52,7 @@ class TemplatesTest extends ControllerTestCase
     {
         $template = factory(Template::class)->create();
 
-        $this->get('backend/renatio/dynamicpdf/templates/preview/' . $template->id)
+        $this->get($this->backendUri . '/renatio/dynamicpdf/templates/preview/' . $template->id)
             ->assertSuccessful();
     }
 


### PR DESCRIPTION
The current test suite has the backend Uri hardcoded as `/backend`. This value is configurable in the cms.php config file. If the user decides to change this value, or in my case, not use one at all, the test suite will fail. 

This PR introduces a new variable to the ControllerTestCase file, called `backendUri` and sets this value equal to the config value. The subsequent references in each of the controller test cases has been updated to use this value. 