### PR TITLE
Podgląd HTML w sandboxie (JS z szablonu w sesji admina)

### DIFF
--- a/controllers/Layouts.php
+++ b/controllers/Layouts.php
@@ -56,7 +56,7 @@ class Layouts extends Controller
     {
         $model = $this->formFindModelObject($id);
 
-        return response($model->html);
+        return response($model->html)->header('Content-Security-Policy', 'sandbox');
     }
 
     public function update_onResetDefault(int|string $recordId): RedirectResponse

--- a/controllers/Layouts.php
+++ b/controllers/Layouts.php
@@ -56,7 +56,7 @@ class Layouts extends Controller
     {
         $model = $this->formFindModelObject($id);
 
-        return response($model->html)->header('Content-Security-Policy', 'sandbox');
+        return response($model->html)->header('Content-Security-Policy', 'sandbox allow-same-origin');
     }
 
     public function update_onResetDefault(int|string $recordId): RedirectResponse

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -78,7 +78,7 @@ class Templates extends Controller
     {
         $model = $this->formFindModelObject($id);
 
-        return response($model->html)->header('Content-Security-Policy', 'sandbox');
+        return response($model->html)->header('Content-Security-Policy', 'sandbox allow-same-origin');
     }
 
     public function update_onResetDefault(int|string $recordId): RedirectResponse

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -78,7 +78,7 @@ class Templates extends Controller
     {
         $model = $this->formFindModelObject($id);
 
-        return response($model->html);
+        return response($model->html)->header('Content-Security-Policy', 'sandbox');
     }
 
     public function update_onResetDefault(int|string $recordId): RedirectResponse

--- a/controllers/layouts/preview.php
+++ b/controllers/layouts/preview.php
@@ -11,7 +11,7 @@
 
 <?php if (! $this->fatalError) : ?>
     <div class="form-preview" style="display: flex; justify-content: center;">
-        <iframe src="<?= Backend::url('renatio/dynamicpdf/layouts/html/'.$formModel->id) ?>"
+        <iframe sandbox src="<?= Backend::url('renatio/dynamicpdf/layouts/html/'.$formModel->id) ?>"
                 style="width: 793px; height: 1121px; border: 1px solid #9098a2;"></iframe>
     </div>
 

--- a/controllers/layouts/preview.php
+++ b/controllers/layouts/preview.php
@@ -11,7 +11,7 @@
 
 <?php if (! $this->fatalError) : ?>
     <div class="form-preview" style="display: flex; justify-content: center;">
-        <iframe sandbox src="<?= Backend::url('renatio/dynamicpdf/layouts/html/'.$formModel->id) ?>"
+        <iframe sandbox="allow-same-origin" src="<?= Backend::url('renatio/dynamicpdf/layouts/html/'.$formModel->id) ?>"
                 style="width: 793px; height: 1121px; border: 1px solid #9098a2;"></iframe>
     </div>
 

--- a/controllers/templates/preview.php
+++ b/controllers/templates/preview.php
@@ -11,7 +11,7 @@
 
 <?php if (! $this->fatalError) : ?>
     <div class="form-preview" style="display: flex; justify-content: center;">
-        <iframe src="<?= Backend::url('renatio/dynamicpdf/templates/html/'.$formModel->id) ?>"
+        <iframe sandbox src="<?= Backend::url('renatio/dynamicpdf/templates/html/'.$formModel->id) ?>"
                 style="width: 793px; height: 1121px; border: 1px solid #9098a2;"></iframe>
     </div>
 

--- a/controllers/templates/preview.php
+++ b/controllers/templates/preview.php
@@ -11,7 +11,7 @@
 
 <?php if (! $this->fatalError) : ?>
     <div class="form-preview" style="display: flex; justify-content: center;">
-        <iframe sandbox src="<?= Backend::url('renatio/dynamicpdf/templates/html/'.$formModel->id) ?>"
+        <iframe sandbox="allow-same-origin" src="<?= Backend::url('renatio/dynamicpdf/templates/html/'.$formModel->id) ?>"
                 style="width: 793px; height: 1121px; border: 1px solid #9098a2;"></iframe>
     </div>
 

--- a/tests/Feature/PreviewHtmlTest.php
+++ b/tests/Feature/PreviewHtmlTest.php
@@ -9,7 +9,7 @@ describe('HTML preview', function () {
 
         $response = (new Templates)->html($template->id);
 
-        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox')
+        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox allow-same-origin')
             ->and($response->getContent())->toContain('<p>Hello</p>');
     });
 
@@ -18,6 +18,6 @@ describe('HTML preview', function () {
 
         $response = (new Layouts)->html($layout->id);
 
-        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox');
+        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox allow-same-origin');
     });
 });

--- a/tests/Feature/PreviewHtmlTest.php
+++ b/tests/Feature/PreviewHtmlTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Renatio\DynamicPDF\Controllers\Layouts;
+use Renatio\DynamicPDF\Controllers\Templates;
+
+describe('HTML preview', function () {
+    it('serves the template HTML sandboxed', function () {
+        $template = $this->createTemplate(['content_html' => '<p>Hello</p><script>alert(1)</script>']);
+
+        $response = (new Templates)->html($template->id);
+
+        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox')
+            ->and($response->getContent())->toContain('<p>Hello</p>');
+    });
+
+    it('serves the layout HTML sandboxed', function () {
+        $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
+
+        $response = (new Layouts)->html($layout->id);
+
+        expect($response->headers->get('Content-Security-Policy'))->toBe('sandbox');
+    });
+});

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -57,5 +57,6 @@ v8.0.2: Update dependencies.
 v8.0.3: Refactor to use pluck() function.
 v8.0.4:
     - Security fix. Disable inline PHP in backend preview.
+    - Security fix. Sandbox the HTML preview so template scripts cannot run in the backend session.
     - Require PHP 8.2 and October CMS 4.0.
     - Render templates and layouts with empty content instead of failing.


### PR DESCRIPTION
## Problem
`templates/html/:id` i `layouts/html/:id` zwracały surowy HTML po Twigu z domeny panelu, osadzony w iframe tej samej domeny. `<script>` z szablonu wykonywał się w sesji administratora otwierającego podgląd.

## Rozwiązanie
- odpowiedź `html()` ma nagłówek `Content-Security-Policy: sandbox` (chroni także otwarcie adresu bezpośrednio),
- iframe w `preview.php` obu kontrolerów ma atrybut `sandbox` (bez `allow-scripts` i `allow-same-origin`),
- wpis w `version.yaml` pod 8.0.4.

Podgląd HTML nie potrzebuje JS, więc nic nie traci; CSS i obrazy z hosta aplikacji ładują się nadal.

## Testy
`tests/Feature/PreviewHtmlTest.php` sprawdza nagłówek dla szablonu i layoutu (czerwone przed poprawką).

Bazuje na #138 (`chore/dev-tooling`); po jego merge przestawić base na `master`.

Closes #117
