### PR TITLE
Certyfikaty self-signed tylko z konfiguracji, metoda publiczna i łańcuchowalna

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,21 @@ Available options and their defaults:
 
 See [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php) for a list of available options.
 
+### Self-signed certificates
+
+Remote resources (requires `enable_remote` in the dompdf configuration) are fetched with full TLS verification. On a
+development host with a self-signed certificate set `DYNAMICPDF_ALLOW_SELF_SIGNED=true` in `.env` (or
+`allow_self_signed_certificates` in `config/renatio/dynamicpdf.php`), or call `allowSelfSignedCertificates()` on the
+wrapper for a single document. The setting applies to every wrapper instance, including `loadHTML()` and after
+`setOptions()`.
+
 ## Methods
 
 | Method                                                  | Description                                              |
 |---------------------------------------------------------|----------------------------------------------------------|
 | loadTemplate($code, array $data = [], $encoding = null) | Load backend template                                    |
 | loadLayout($code, array $data = [], $encoding = null)   | Load backend layout                                      |
+| allowSelfSignedCertificates()                           | Accept self-signed TLS certificates for remote resources |
 | loadHTML($string, $encoding = null)                     | Load HTML string                                         |
 | loadFile($file)                                         | Load HTML string from a file                             |
 | parseTemplate(Template $template, array $data = [])     | Parse backend template using Twig                        |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -69,5 +69,9 @@ Calling an option setter that does not exist on the wrapper, dompdf or its optio
 `setRemoteEnabled()`, or `setAdminUsername()` removed by dompdf) now throws `UnexpectedValueException` instead of being
 silently ignored.
 
+TLS certificates are verified on every environment. On a development host with a self-signed certificate set
+`DYNAMICPDF_ALLOW_SELF_SIGNED=true` in `.env` (or `allow_self_signed_certificates` in `config/renatio/dynamicpdf.php`),
+or call the now public `allowSelfSignedCertificates()` on the wrapper for a single document.
+
 The backend HTML and PDF preview no longer enables inline PHP. If you use the demo templates, open the
 **Header and Footer** layout and click **Reset to default** to remove the page number script from the stored copy.

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -4,7 +4,11 @@ namespace Renatio\DynamicPDF\Classes;
 
 use Barryvdh\DomPDF\PDF;
 use Cms\Classes\Controller;
+use Dompdf\Dompdf;
 use Exception;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Filesystem\Filesystem;
 use October\Rain\Support\Facades\Twig;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
@@ -20,6 +24,25 @@ use UnexpectedValueException;
  */
 class PDFWrapper extends PDF
 {
+    public function __construct(Dompdf $dompdf, ConfigRepository $config, Filesystem $files, ViewFactory $view)
+    {
+        parent::__construct($dompdf, $config, $files, $view);
+
+        $this->applyCertificatePolicy();
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function setOptions(array $options, bool $mergeWithDefaults = false): self
+    {
+        parent::setOptions($options, $mergeWithDefaults);
+
+        $this->applyCertificatePolicy();
+
+        return $this;
+    }
+
     public function __call($method, $parameters)
     {
         if (method_exists($this, $method)) {
@@ -59,8 +82,6 @@ class PDFWrapper extends PDF
             $this->setPaper($template->size, $template->orientation ?? 'portrait');
         }
 
-        $this->allowSelfSignedCertificates();
-
         return $this;
     }
 
@@ -73,8 +94,6 @@ class PDFWrapper extends PDF
             $this->parseLayout(Layout::byCode($code), $data),
             $encoding,
         );
-
-        $this->allowSelfSignedCertificates();
 
         return $this;
     }
@@ -171,12 +190,8 @@ class PDFWrapper extends PDF
         )));
     }
 
-    protected function allowSelfSignedCertificates(): void
+    public function allowSelfSignedCertificates(): self
     {
-        if (app()->environment('production')) {
-            return;
-        }
-
         $current = $this->dompdf->getHttpContext();
 
         $context = stream_context_create(array_merge_recursive(
@@ -191,5 +206,14 @@ class PDFWrapper extends PDF
         ));
 
         $this->dompdf->setHttpContext($context);
+
+        return $this;
+    }
+
+    protected function applyCertificatePolicy(): void
+    {
+        if (config('renatio.dynamicpdf.allow_self_signed_certificates')) {
+            $this->allowSelfSignedCertificates();
+        }
     }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'allow_self_signed_certificates' => env('DYNAMICPDF_ALLOW_SELF_SIGNED', false),
+
+];

--- a/tests/Unit/Classes/SelfSignedCertificatesTest.php
+++ b/tests/Unit/Classes/SelfSignedCertificatesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+describe('Self-signed certificates', function () {
+    it('ships with verification enabled', function () {
+        expect(config('renatio.dynamicpdf.allow_self_signed_certificates'))->toBeFalse();
+    });
+
+    it('leaves the dompdf HTTP context untouched by default', function () {
+        config(['renatio.dynamicpdf.allow_self_signed_certificates' => false]);
+        $template = $this->createTemplate();
+
+        $wrapper = app('dynamicpdf')->loadTemplate($template->code);
+
+        expect(stream_context_get_options($wrapper->getDomPDF()->getHttpContext()))->not->toHaveKey('ssl');
+    });
+
+    it('accepts self-signed certificates for loadHTML when the config enables it', function () {
+        config(['renatio.dynamicpdf.allow_self_signed_certificates' => true]);
+
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>Hello</p>');
+
+        expect(stream_context_get_options($wrapper->getDomPDF()->getHttpContext())['ssl']['verify_peer'])->toBeFalse();
+    });
+
+    it('keeps the policy after setOptions replaces the dompdf options', function () {
+        config(['renatio.dynamicpdf.allow_self_signed_certificates' => true]);
+
+        $wrapper = app('dynamicpdf')->setOptions(['isRemoteEnabled' => true]);
+        $options = stream_context_get_options($wrapper->getDomPDF()->getHttpContext());
+
+        expect($options['ssl']['verify_peer'])->toBeFalse()
+            ->and($options['http']['follow_location'])->toBeFalse();
+    });
+
+    it('is chainable when called explicitly', function () {
+        $wrapper = app('dynamicpdf');
+
+        expect($wrapper->allowSelfSignedCertificates())->toBe($wrapper)
+            ->and(stream_context_get_options($wrapper->getDomPDF()->getHttpContext())['ssl']['allow_self_signed'])->toBeTrue();
+    });
+});

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -59,6 +59,7 @@ v8.0.4:
     - Security fix. Disable inline PHP in backend preview.
     - Security fix. Sandbox the HTML preview so template scripts cannot run in the backend session.
     - Security fix. Limit remote resources in the backend preview to the application host.
+    - Security fix. Self-signed certificates are accepted only with the allow_self_signed_certificates config, not on every non-production environment.
     - Require PHP 8.2 and October CMS 4.0.
     - Render templates and layouts with empty content instead of failing.
     - Throw on unknown wrapper methods instead of ignoring them.


### PR DESCRIPTION
## Problem
`allowSelfSignedCertificates()` wyłączało weryfikację TLS na każdym środowisku poza `production` (staging włącznie), bez możliwości zmiany. Dodatkowo metoda była `protected` i zwracała `void`, więc wołana z zewnątrz przez `__call` urywała łańcuch (#114).

## Rozwiązanie
- `config/config.php` pluginu z kluczem `allow_self_signed_certificates` (`DYNAMICPDF_ALLOW_SELF_SIGNED`, domyślnie `false`), scalany przez `mergeConfigFrom()` jak w twofactorauth,
- `loadTemplate()` / `loadLayout()` stosują politykę z konfiguracji,
- `allowSelfSignedCertificates()` publiczna, zwraca `$this`,
- README (sekcja Self-signed certificates i tabela metod), UPGRADE.md pod 8.0.4, `version.yaml`.

## Testy
`tests/Unit/Classes/SelfSignedCertificatesTest.php`: domyślnie `verify_peer` zostaje włączone, z konfiguracją wyłączone, wywołanie jawne łańcuchowalne. Pierwsze dwa czerwone przed poprawką.

Bazuje na #138 (`chore/dev-tooling`); po jego merge przestawić base na `master`.

Closes #118
Closes #114
