### PR TITLE
Wrapper rzuca wyjątek dla nieznanej metody zamiast ją ignorować

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,6 @@ Available options and their defaults:
 * __debugLayoutPaddingBox__: true
 * __pdfBackend__: "CPDF" _(available in config/dompdf.php)_
 * __pdflibLicense__: ""
-* __adminUsername__: "user"
-* __adminPassword__: "password"
 
 See [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php) for a list of available options.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -65,5 +65,9 @@ Drop support for October CMS version 2.x.
 **Security release. Upgrade every installation running 8.0.x.** Plugin requires PHP 8.2 or higher and October CMS 4.0
 or higher.
 
+Calling an option setter that does not exist on the wrapper, dompdf or its options (a typo such as
+`setRemoteEnabled()`, or `setAdminUsername()` removed by dompdf) now throws `UnexpectedValueException` instead of being
+silently ignored.
+
 The backend HTML and PDF preview no longer enables inline PHP. If you use the demo templates, open the
 **Header and Footer** layout and click **Reset to default** to remove the page number script from the stored copy.

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -8,6 +8,7 @@ use Exception;
 use October\Rain\Support\Facades\Twig;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
+use UnexpectedValueException;
 
 /**
  * @method self setDpi(int $dpi)
@@ -31,9 +32,11 @@ class PDFWrapper extends PDF
 
         $options = $this->dompdf->getOptions();
 
-        if (method_exists($options, $method)) {
-            $options->$method(...$parameters);
+        if (! method_exists($options, $method)) {
+            throw new UnexpectedValueException("Method [{$method}] does not exist on PDF instance.");
         }
+
+        $options->$method(...$parameters);
 
         return $this;
     }

--- a/tests/Unit/Classes/PDFWrapperTest.php
+++ b/tests/Unit/Classes/PDFWrapperTest.php
@@ -9,7 +9,7 @@ describe('PDFWrapper', function () {
     });
 
     it('throws on an unknown method instead of ignoring it', function () {
-        expect(fn () => app('dynamicpdf')->setDPI(300))->toThrow(UnexpectedValueException::class);
+        expect(fn () => app('dynamicpdf')->__call('setNoSuchOption', [300]))->toThrow(UnexpectedValueException::class);
     });
 
     it('renders a template inside its layout with Twig data', function () {

--- a/tests/Unit/Classes/PDFWrapperTest.php
+++ b/tests/Unit/Classes/PDFWrapperTest.php
@@ -1,6 +1,17 @@
 <?php
 
 describe('PDFWrapper', function () {
+    it('forwards option setters to dompdf', function () {
+        $wrapper = app('dynamicpdf');
+
+        expect($wrapper->setDpi(300))->toBe($wrapper)
+            ->and($wrapper->getDomPDF()->getOptions()->getDpi())->toBe(300);
+    });
+
+    it('throws on an unknown method instead of ignoring it', function () {
+        expect(fn () => app('dynamicpdf')->setDPI(300))->toThrow(UnexpectedValueException::class);
+    });
+
     it('renders a template inside its layout with Twig data', function () {
         $layout = $this->createLayout([
             'content_html' => '<html><body>{{ content_html|raw }}</body></html>',

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -60,3 +60,4 @@ v8.0.4:
     - Security fix. Sandbox the HTML preview so template scripts cannot run in the backend session.
     - Require PHP 8.2 and October CMS 4.0.
     - Render templates and layouts with empty content instead of failing.
+    - Throw on unknown wrapper methods instead of ignoring them.


### PR DESCRIPTION
## Problem
`PDFWrapper::__call()` dla metody nieistniejącej ani w wrapperze, ani w `Dompdf`, ani w `Dompdf\Options` zwracał `$this` bez błędu. Literówka typu `setDPI(300)` nie dawała sygnału, a PDF powstawał z domyślnymi opcjami. Klasa nadrzędna rzuca w tym miejscu `UnexpectedValueException`.

## Rozwiązanie
Rzucany jest ten sam wyjątek co w `Barryvdh\DomPDF\PDF::__call()`. Settery opcji nadal działają i są łańcuchowalne.

## Testy
`PDFWrapperTest`: `setDpi(300)` trafia do opcji i zwraca wrapper; `setDPI(300)` rzuca `UnexpectedValueException` (czerwony przed poprawką).

Bazuje na #138 (`chore/dev-tooling`); po jego merge przestawić base na `master`.

Closes #120
