### PR TITLE
byCode(): fallback do zarejestrowanego widoku, gdy rekordu nie ma w bazie

### DIFF
--- a/classes/SyncTemplates.php
+++ b/classes/SyncTemplates.php
@@ -59,7 +59,6 @@ class SyncTemplates
             }
 
             $layout = new Layout;
-            $layout->code = $code;
             $layout->is_locked = true;
             $layout->fillFromView($code);
             $layout->save();

--- a/models/Layout.php
+++ b/models/Layout.php
@@ -49,16 +49,15 @@ class Layout extends Model
     {
         $layout = static::whereCode($code)->first();
 
-        if ($layout instanceof self) {
+        if ($layout instanceof static) {
             return $layout;
         }
 
         if (! array_key_exists($code, PDFManager::instance()->listRegisteredLayouts() ?? [])) {
-            throw (new ModelNotFoundException)->setModel(self::class, [$code]);
+            throw (new ModelNotFoundException)->setModel(static::class, [$code]);
         }
 
         $layout = new self;
-        $layout->code = $code;
         $layout->fillFromView($code);
 
         return $layout;
@@ -88,6 +87,7 @@ class Layout extends Model
     {
         $sections = PDFParser::sections($path);
 
+        $this->code = $path;
         $this->name = array_get($sections, 'settings.name', '???');
         $this->content_css = array_get($sections, 'css');
         $this->content_html = array_get($sections, 'html');

--- a/models/Layout.php
+++ b/models/Layout.php
@@ -2,6 +2,7 @@
 
 namespace Renatio\DynamicPDF\Models;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Less_Parser;
 use October\Rain\Database\Model;
 use October\Rain\Database\Traits\Validation;
@@ -46,7 +47,21 @@ class Layout extends Model
 
     public static function byCode(string $code): self
     {
-        return static::whereCode($code)->firstOrFail();
+        $layout = static::whereCode($code)->first();
+
+        if ($layout instanceof self) {
+            return $layout;
+        }
+
+        if (! array_key_exists($code, PDFManager::instance()->listRegisteredLayouts() ?? [])) {
+            throw (new ModelNotFoundException)->setModel(self::class, [$code]);
+        }
+
+        $layout = new self;
+        $layout->code = $code;
+        $layout->fillFromView($code);
+
+        return $layout;
     }
 
     public function getCSS(): string

--- a/models/Template.php
+++ b/models/Template.php
@@ -3,6 +3,7 @@
 namespace Renatio\DynamicPDF\Models;
 
 use Dompdf\Adapter\CPDF;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use October\Rain\Database\Model;
 use October\Rain\Database\Traits\Validation;
 use October\Rain\Exception\ApplicationException;
@@ -77,9 +78,26 @@ class Template extends Model
         return PDF::loadTemplate($this->code)->getDompdf()->output_html();
     }
 
+    /**
+     * A registered view that is not stored yet (for example before the first backend
+     * request synchronised it) renders straight from the file.
+     */
     public static function byCode(string $code): self
     {
-        return static::whereCode($code)->firstOrFail();
+        $template = static::whereCode($code)->first();
+
+        if ($template instanceof self) {
+            return $template;
+        }
+
+        if (! array_key_exists($code, PDFManager::instance()->listRegisteredTemplates() ?? [])) {
+            throw (new ModelNotFoundException)->setModel(self::class, [$code]);
+        }
+
+        $template = new self;
+        $template->fillFromView($code);
+
+        return $template;
     }
 
     /**

--- a/models/Template.php
+++ b/models/Template.php
@@ -66,11 +66,24 @@ class Template extends Model
 
         $this->title = array_get($sections, 'settings.title', '???');
         $this->code = $path;
-        $this->setAttribute('layout', Layout::whereCode(array_get($sections, 'settings.layout'))->first());
+        $this->setAttribute('layout', $this->resolveLayout(array_get($sections, 'settings.layout')));
         $this->size = array_get($sections, 'settings.size');
         $this->orientation = array_get($sections, 'settings.orientation');
         $this->description = array_get($sections, 'settings.description');
         $this->content_html = array_get($sections, 'html');
+    }
+
+    protected function resolveLayout(?string $code): ?Layout
+    {
+        if (! $code) {
+            return null;
+        }
+
+        try {
+            return Layout::byCode($code);
+        } catch (ModelNotFoundException) {
+            return null;
+        }
     }
 
     public function getHtmlAttribute(): string
@@ -86,12 +99,12 @@ class Template extends Model
     {
         $template = static::whereCode($code)->first();
 
-        if ($template instanceof self) {
+        if ($template instanceof static) {
             return $template;
         }
 
         if (! array_key_exists($code, PDFManager::instance()->listRegisteredTemplates() ?? [])) {
-            throw (new ModelNotFoundException)->setModel(self::class, [$code]);
+            throw (new ModelNotFoundException)->setModel(static::class, [$code]);
         }
 
         $template = new self;

--- a/tests/Unit/Models/RegisteredViewFallbackTest.php
+++ b/tests/Unit/Models/RegisteredViewFallbackTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Registered view fallback', function () {
+    it('builds a template from its registered view when the record does not exist', function () {
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+
+        $template = Template::byCode('renatio.dynamicpdf::pdf.invoice');
+
+        expect($template->exists)->toBeFalse()
+            ->and($template->title)->toBe('Invoice')
+            ->and($template->content_html)->toContain('Invoice');
+    });
+
+    it('builds a layout from its registered view when the record does not exist', function () {
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
+
+        $layout = Layout::byCode('renatio.dynamicpdf::pdf.layouts.default');
+
+        expect($layout->exists)->toBeFalse()
+            ->and($layout->name)->toBe('Default Layout');
+    });
+
+    it('still throws for a code that is neither stored nor registered', function () {
+        expect(fn () => Template::byCode('non.existent::pdf.template'))->toThrow(ModelNotFoundException::class);
+    });
+});

--- a/tests/Unit/Models/RegisteredViewFallbackTest.php
+++ b/tests/Unit/Models/RegisteredViewFallbackTest.php
@@ -6,22 +6,33 @@ use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 
 describe('Registered view fallback', function () {
-    it('builds a template from its registered view when the record does not exist', function () {
+    beforeEach(function () {
         PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
+    });
 
+    afterEach(fn () => PDFManager::forgetInstance());
+
+    it('builds a template from its registered view when the record does not exist', function () {
         $template = Template::byCode('renatio.dynamicpdf::pdf.invoice');
 
         expect($template->exists)->toBeFalse()
             ->and($template->title)->toBe('Invoice')
-            ->and($template->content_html)->toContain('Invoice');
+            ->and($template->layout?->name)->toBe('Default Layout');
+    });
+
+    it('renders the template inside its registered layout', function () {
+        $html = app('dynamicpdf')->parseTemplate(Template::byCode('renatio.dynamicpdf::pdf.invoice'));
+
+        expect($html)->toContain('<!DOCTYPE html>')
+            ->and($html)->toContain('<h1 class="text-4xl font-bold leading-none">Invoice</h1>');
     });
 
     it('builds a layout from its registered view when the record does not exist', function () {
-        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
-
         $layout = Layout::byCode('renatio.dynamicpdf::pdf.layouts.default');
 
         expect($layout->exists)->toBeFalse()
+            ->and($layout->code)->toBe('renatio.dynamicpdf::pdf.layouts.default')
             ->and($layout->name)->toBe('Default Layout');
     });
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -61,3 +61,4 @@ v8.0.4:
     - Require PHP 8.2 and October CMS 4.0.
     - Render templates and layouts with empty content instead of failing.
     - Throw on unknown wrapper methods instead of ignoring them.
+    - Render a registered template or layout from its view when it is not stored yet.


### PR DESCRIPTION
## Problem
README (*Using PDF templates*) obiecuje: „If the PDF template does not exist in the system, this code will attempt to find a PDF view with the same code”. `Template::byCode()` i `Layout::byCode()` robiły `firstOrFail()`, więc fallbacku nie było. Objaw: pierwsze żądanie frontendowe po deployu, zanim synchronizacja utworzyła rekord (albo gdy zawiodła, #115), kończyło się 404.

## Rozwiązanie
`byCode()` zwraca rekord z bazy, a gdy go nie ma i kod jest zarejestrowany w `PDFManager`, buduje niezapisany model z pliku widoku (`fillFromView()`). Dla kodu nieznanego nadal `ModelNotFoundException`. Kod i README mówią teraz to samo; wpis w `version.yaml`.

## Testy
`tests/Unit/Models/RegisteredViewFallbackTest.php`: szablon i layout demo renderują się z widoku bez rekordu (`exists === false`), nieznany kod rzuca. Dwa pierwsze czerwone przed poprawką.

Bazuje na #138 (`chore/dev-tooling`); po jego merge przestawić base na `master`.

Closes #119
