### PR TITLE
Twig z modułu System, gdy Cms jest niedostępny; błędy Twig nie są ukrywane

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ public function registerPDFLayouts()
 
 The method should return an array of pdf view names.
 
+## Twig environment
+
+Templates and layouts are rendered with the CMS Twig environment when the Cms module is installed and a theme is
+active, so theme partials and content blocks are available. Otherwise, for example in a backend-only installation
+that loads only the System and Backend modules, the system Twig environment is used. Filters and functions registered
+by plugins through `registerMarkupTags` work in both.
+
 ## Usage
 
 PDF templates and layouts can be accessed in the back-end area via *Settings > PDF > PDF Templates*.

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -4,16 +4,18 @@ namespace Renatio\DynamicPDF\Classes;
 
 use Barryvdh\DomPDF\PDF;
 use Cms\Classes\Controller;
+use Cms\Classes\Theme;
 use Dompdf\Dompdf;
 use Exception;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
-use October\Rain\Support\Facades\Twig;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\SiteManager;
+use System\Facades\System;
 use System\Models\SiteDefinition;
+use Twig\Environment;
 use UnexpectedValueException;
 
 /**
@@ -147,14 +149,27 @@ class PDFWrapper extends PDF
             return '';
         }
 
-        try {
-            $twig = (new Controller)->getTwig();
-            $template = $twig->createTemplate($markup);
+        return $this->twig()->createTemplate($markup)->render($data);
+    }
 
-            return $template->render($data);
-        } catch (Exception) {
-            return Twig::parse($markup, $data);
+    /**
+     * The CMS environment adds theme partials and content on top of the system one, so it
+     * is used whenever the module is installed and a usable theme is active. Looking the
+     * theme up can itself throw (no theme configured, a locked theme), which must not stop
+     * a PDF from rendering.
+     */
+    protected function twig(): Environment
+    {
+        if (System::hasModule('Cms')) {
+            try {
+                if (Theme::getActiveTheme() !== null) {
+                    return (new Controller)->getTwig();
+                }
+            } catch (Exception) {
+            }
         }
+
+        return app('twig.environment');
     }
 
     /**

--- a/tests/Unit/Classes/TwigEnvironmentTest.php
+++ b/tests/Unit/Classes/TwigEnvironmentTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Cms\Classes\Theme;
+use Illuminate\Support\Facades\Event;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Loader\ArrayLoader;
+use Twig\TwigFunction;
+
+describe('Twig environment', function () {
+    afterEach(function () {
+        Event::forget('cms.theme.getActiveTheme');
+        Theme::resetCache();
+        app()->forgetInstance('twig.environment');
+    });
+
+    it('renders through the CMS environment when a theme is active', function () {
+        Event::listen('cms.theme.getActiveTheme', fn (): string => 'demo');
+        Theme::resetCache();
+        $template = $this->createTemplate(['content_html' => "{{ 'assets/css/theme.css'|theme }}"]);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toContain('themes/demo/assets/css/theme.css');
+    });
+
+    it('renders through the system environment when no theme is active', function () {
+        $twig = new Environment(new ArrayLoader);
+        $twig->addFunction(new TwigFunction('probe', fn (): string => 'system twig'));
+        app()->instance('twig.environment', $twig);
+        $template = $this->createTemplate(['content_html' => '{{ probe() }}']);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toBe('system twig');
+    });
+
+    it('falls back to the system environment when the theme lookup throws', function () {
+        config(['cms.active_theme' => '']);
+        Theme::resetCache();
+        $template = $this->createTemplate(['content_html' => "{{ '**bold**'|md }}"]);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toBe('<p><strong>bold</strong></p>');
+    });
+
+    it('reports a CMS rendering error instead of retrying with the system environment', function () {
+        Event::listen('cms.theme.getActiveTheme', fn (): string => 'demo');
+        Theme::resetCache();
+        $template = $this->createTemplate(['content_html' => '<p>{{ name </p>']);
+
+        expect(fn () => app('dynamicpdf')->parseTemplate($template))->toThrow(SyntaxError::class);
+    });
+});

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -64,3 +64,4 @@ v8.0.4:
     - Render templates and layouts with empty content instead of failing.
     - Throw on unknown wrapper methods instead of ignoring them.
     - Render a registered template or layout from its view when it is not stored yet.
+    - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
`PDFWrapper::parseMarkup()` budował Twiga przez `new Cms\Classes\Controller`. W instalacji bez modułu Cms (`LOAD_MODULES="System,Backend"`, mplodowski/cico-www#192) leciał `Error`, którego `catch (Exception)` nie łapał. Sam `catch` ukrywał też błędy składni Twig i parsował szablon drugi raz (#121).

## Rozwiązanie
- `twig()`: gdy moduł Cms jest załadowany i jest aktywny motyw, środowisko z kontrolera CMS (partiale i content z motywu działają jak dotąd); w przeciwnym razie `app('twig.environment')` z modułu System, które ma `System\Twig\Extension` (a więc filtry z `registerMarkupTags` wszystkich pluginów) i `SecurityPolicy`,
- brak `try/catch`, błędy Twig propagują się,
- README: sekcja *Twig environment*; wpis w `version.yaml`.

Założenie z cico-www#192, że `Twig::parse()` nie zna filtrów pluginów, okazało się błędne: `twig.environment` Systemu deleguje do `MarkupManager`. Problemem był wyłącznie nieprzechwycony `Error`.

## Testy
`tests/Unit/Classes/TwigEnvironmentTest.php`: filtry systemowe (`md`, `upper`) działają; bez aktywnego motywu render idzie przez `twig.environment` (podstawiony probe); błąd składni to `Twig\Error\SyntaxError`.

Bazuje na #138 (`chore/dev-tooling`); po jego merge przestawić base na `master`.

Closes #129
Closes #121
