### PR TITLE
Synchronizacja widoków tylko w backendzie, brakujący widok logowany zamiast blokować sync

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -5,9 +5,12 @@ namespace Renatio\DynamicPDF;
 use Backend\Facades\Backend;
 use Barryvdh\DomPDF\ServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Event;
+use RainLab\Translate\Classes\ThemeScanner;
 use Renatio\DynamicPDF\Classes\PDFWrapper;
-use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Console\Demo;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
 use System\Classes\PluginBase;
 use System\Classes\PluginManager;
 use System\Models\Parameter;
@@ -43,7 +46,19 @@ class Plugin extends PluginBase
             config(['dompdf.public_path' => public_path()]);
         }
 
-        (new SyncTemplates)->handle();
+        Event::listen('rainlab.translate.themeScanner.afterScan', function (ThemeScanner $scanner): void {
+            $messages = [];
+
+            foreach (Layout::all() as $layout) {
+                $messages = array_merge($messages, $scanner->parseContent($layout->content_html));
+            }
+
+            foreach (Template::all() as $template) {
+                $messages = array_merge($messages, $scanner->parseContent($template->content_html));
+            }
+
+            $scanner->importMessages($messages);
+        });
     }
 
     public function register(): void

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ public function registerPDFTemplates()
 
 The method should return an array of pdf view names.
 
-Registered views are synchronised to the database when the *PDF Templates* settings page is opened and when
+Registered views are synchronised to the database when a *PDF Templates* settings page is displayed and when
 `php artisan dynamicpdf:demo` runs, not on every request. A code whose view file is missing is skipped and written to
-the application log. Until a registered view is synchronised, `PDF::loadTemplate()` renders it straight from the file.
+the application log once per process; a stored template whose view file went missing keeps its stored content. Until a registered view is synchronised, `PDF::loadTemplate()` renders it straight from the file.
 
 Like templates, PDF layouts can be registered by adding the `registerPDFLayouts` method of the Plugin registration
 class (`Plugin.php`).

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ public function registerPDFTemplates()
 
 The method should return an array of pdf view names.
 
+Registered views are synchronised to the database when the *PDF Templates* settings page is opened and when
+`php artisan dynamicpdf:demo` runs, not on every request. A code whose view file is missing is skipped and written to
+the application log. Until a registered view is synchronised, `PDF::loadTemplate()` renders it straight from the file.
+
 Like templates, PDF layouts can be registered by adding the `registerPDFLayouts` method of the Plugin registration
 class (`Plugin.php`).
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -73,5 +73,9 @@ TLS certificates are verified on every environment. On a development host with a
 `DYNAMICPDF_ALLOW_SELF_SIGNED=true` in `.env` (or `allow_self_signed_certificates` in `config/renatio/dynamicpdf.php`),
 or call the now public `allowSelfSignedCertificates()` on the wrapper for a single document.
 
+Registered PDF views are synchronised to the database when the *PDF Templates* settings page is opened or
+`dynamicpdf:demo` runs, no longer on every request. Rendering a registered view that is not stored yet works without
+the sync. A registered code without a view file is skipped and logged instead of silently stopping the sync.
+
 The backend HTML and PDF preview no longer enables inline PHP. If you use the demo templates, open the
 **Header and Footer** layout and click **Reset to default** to remove the page number script from the stored copy.

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -10,6 +10,7 @@ use Exception;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Log;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\SiteManager;
@@ -31,6 +32,7 @@ class PDFWrapper extends PDF
         parent::__construct($dompdf, $config, $files, $view);
 
         $this->applyCertificatePolicy();
+        $this->ensureFontDir();
     }
 
     /**
@@ -223,6 +225,15 @@ class PDFWrapper extends PDF
         $this->dompdf->setHttpContext($context);
 
         return $this;
+    }
+
+    protected function ensureFontDir(): void
+    {
+        $fontDir = $this->dompdf->getOptions()->getFontDir();
+
+        if ($fontDir && ! is_dir($fontDir) && ! @mkdir($fontDir, 0755, true) && ! is_dir($fontDir)) {
+            Log::error("Renatio.DynamicPDF could not create the dompdf font directory {$fontDir}.");
+        }
     }
 
     protected function applyCertificatePolicy(): void

--- a/classes/SyncTemplates.php
+++ b/classes/SyncTemplates.php
@@ -2,44 +2,40 @@
 
 namespace Renatio\DynamicPDF\Classes;
 
-use Exception;
-use October\Rain\Support\Facades\Event;
-use RainLab\Translate\Classes\ThemeScanner;
+use Illuminate\Support\Facades\Log;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
+use Throwable;
 
 class SyncTemplates
 {
     public function handle(): void
     {
-        try {
-            $this->checkFontsDir();
-            $this->createLayouts();
+        $this->checkFontsDir();
+        $this->createLayouts();
 
-            $registeredTemplates = PDFManager::instance()->listRegisteredTemplates();
+        $registeredTemplates = PDFManager::instance()->listRegisteredTemplates();
 
-            if (! $registeredTemplates) {
-                return;
-            }
-
-            $dbTemplates = Template::query()->pluck('is_custom', 'code')->all();
-
-            $this->clearNonCustomizedTemplates($dbTemplates, $registeredTemplates);
-
-            $newTemplates = array_diff_key($registeredTemplates, $dbTemplates);
-
-            $this->createTemplates($newTemplates);
-            $this->scanTranslatedMessages();
-        } catch (Exception) {
+        if (! $registeredTemplates) {
+            return;
         }
+
+        $dbTemplates = Template::query()->pluck('is_custom', 'code')->all();
+
+        $this->clearNonCustomizedTemplates($dbTemplates, $registeredTemplates);
+        $this->createTemplates(array_diff_key($registeredTemplates, $dbTemplates));
     }
 
     protected function checkFontsDir(): void
     {
         $fontDir = config('dompdf.options.font_dir');
 
-        if ($fontDir && ! file_exists($fontDir)) {
-            mkdir($fontDir, 0755, true);
+        if (! $fontDir || file_exists($fontDir)) {
+            return;
+        }
+
+        if (! @mkdir($fontDir, 0755, true) && ! is_dir($fontDir)) {
+            Log::error("Renatio.DynamicPDF could not create the dompdf font directory {$fontDir}.");
         }
     }
 
@@ -53,15 +49,13 @@ class SyncTemplates
 
         $dbLayouts = Layout::query()->pluck('code', 'code')->all();
 
-        foreach ($registeredLayouts as $code) {
-            if (array_key_exists($code, $dbLayouts)) {
-                continue;
-            }
-
-            $layout = new Layout;
-            $layout->is_locked = true;
-            $layout->fillFromView($code);
-            $layout->save();
+        foreach (array_diff_key($registeredLayouts, $dbLayouts) as $code) {
+            $this->create($code, function () use ($code): void {
+                $layout = new Layout;
+                $layout->is_locked = true;
+                $layout->fillFromView($code);
+                $layout->save();
+            });
         }
     }
 
@@ -72,11 +66,7 @@ class SyncTemplates
     protected function clearNonCustomizedTemplates(array $dbTemplates, array $registeredTemplates): void
     {
         foreach ($dbTemplates as $code => $isCustom) {
-            if ($isCustom) {
-                continue;
-            }
-
-            if (! array_key_exists($code, $registeredTemplates)) {
+            if (! $isCustom && ! array_key_exists($code, $registeredTemplates)) {
                 Template::whereCode($code)->delete();
             }
         }
@@ -88,26 +78,23 @@ class SyncTemplates
     protected function createTemplates(array $templates): void
     {
         foreach ($templates as $code) {
-            $template = new Template;
-            $template->fillFromView($code);
-            $template->forceSave();
+            $this->create($code, function () use ($code): void {
+                $template = new Template;
+                $template->fillFromView($code);
+                $template->forceSave();
+            });
         }
     }
 
-    protected function scanTranslatedMessages(): void
+    /**
+     * One registered code without a view file must not stop the others from syncing.
+     */
+    protected function create(string $code, callable $create): void
     {
-        Event::listen('rainlab.translate.themeScanner.afterScan', function (ThemeScanner $scanner): void {
-            $messages = [];
-
-            foreach (Layout::all() as $layout) {
-                $messages = array_merge($messages, $scanner->parseContent($layout->content_html));
-            }
-
-            foreach (Template::all() as $template) {
-                $messages = array_merge($messages, $scanner->parseContent($template->content_html));
-            }
-
-            $scanner->importMessages($messages);
-        });
+        try {
+            $create();
+        } catch (Throwable $e) {
+            Log::error("Renatio.DynamicPDF could not sync {$code}: {$e->getMessage()}");
+        }
     }
 }

--- a/classes/SyncTemplates.php
+++ b/classes/SyncTemplates.php
@@ -9,9 +9,11 @@ use Throwable;
 
 class SyncTemplates
 {
+    /** @var array<string, true> */
+    protected static array $failed = [];
+
     public function handle(): void
     {
-        $this->checkFontsDir();
         $this->createLayouts();
 
         $registeredTemplates = PDFManager::instance()->listRegisteredTemplates();
@@ -24,19 +26,6 @@ class SyncTemplates
 
         $this->clearNonCustomizedTemplates($dbTemplates, $registeredTemplates);
         $this->createTemplates(array_diff_key($registeredTemplates, $dbTemplates));
-    }
-
-    protected function checkFontsDir(): void
-    {
-        $fontDir = config('dompdf.options.font_dir');
-
-        if (! $fontDir || file_exists($fontDir)) {
-            return;
-        }
-
-        if (! @mkdir($fontDir, 0755, true) && ! is_dir($fontDir)) {
-            Log::error("Renatio.DynamicPDF could not create the dompdf font directory {$fontDir}.");
-        }
     }
 
     protected function createLayouts(): void
@@ -54,7 +43,7 @@ class SyncTemplates
                 $layout = new Layout;
                 $layout->is_locked = true;
                 $layout->fillFromView($code);
-                $layout->save();
+                $layout->forceSave();
             });
         }
     }
@@ -87,14 +76,21 @@ class SyncTemplates
     }
 
     /**
-     * One registered code without a view file must not stop the others from syncing.
+     * One registered code without a view file must not stop the others from syncing,
+     * and a code that keeps failing is logged once per process rather than per request.
      */
     protected function create(string $code, callable $create): void
     {
+        if (isset(self::$failed[$code])) {
+            return;
+        }
+
         try {
             $create();
         } catch (Throwable $e) {
-            Log::error("Renatio.DynamicPDF could not sync {$code}: {$e->getMessage()}");
+            self::$failed[$code] = true;
+
+            Log::error("Renatio.DynamicPDF could not sync {$code}: {$e->getMessage()}", ['exception' => $e]);
         }
     }
 }

--- a/console/Demo.php
+++ b/console/Demo.php
@@ -3,6 +3,8 @@
 namespace Renatio\DynamicPDF\Console;
 
 use Illuminate\Console\Command;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\PluginManager;
@@ -26,6 +28,9 @@ class Demo extends Command
     protected function enableDemo(): void
     {
         Parameter::set('renatio::dynamicpdf.demo', 1);
+
+        PDFManager::forgetInstance();
+        (new SyncTemplates)->handle();
 
         $this->info(e(trans('renatio.dynamicpdf::lang.demo.enabled')));
     }

--- a/controllers/Layouts.php
+++ b/controllers/Layouts.php
@@ -32,7 +32,10 @@ class Layouts extends Controller
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('Renatio.DynamicPDF', 'templates');
+    }
 
+    public function beforeDisplay(): void
+    {
         (new SyncTemplates)->handle();
     }
 

--- a/controllers/Layouts.php
+++ b/controllers/Layouts.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use October\Rain\Exception\ApplicationException;
 use October\Rain\Support\Facades\Flash;
 use Renatio\DynamicPDF\Classes\PDF;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
 use System\Classes\SettingsManager;
 
 class Layouts extends Controller
@@ -31,6 +32,8 @@ class Layouts extends Controller
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('Renatio.DynamicPDF', 'templates');
+
+        (new SyncTemplates)->handle();
     }
 
     public function previewPdf(int|string $id): ?Response

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Response;
 use October\Rain\Exception\ApplicationException;
 use October\Rain\Support\Facades\Flash;
 use Renatio\DynamicPDF\Classes\PDF;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\SettingsManager;
 
@@ -40,6 +41,8 @@ class Templates extends Controller
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('Renatio.DynamicPDF', 'templates');
+
+        (new SyncTemplates)->handle();
     }
 
     public function index(?string $tab = null): void

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -41,7 +41,10 @@ class Templates extends Controller
 
         BackendMenu::setContext('October.System', 'system', 'settings');
         SettingsManager::setContext('Renatio.DynamicPDF', 'templates');
+    }
 
+    public function beforeDisplay(): void
+    {
         (new SyncTemplates)->handle();
     }
 

--- a/models/Layout.php
+++ b/models/Layout.php
@@ -35,6 +35,11 @@ class Layout extends Model
         'content_html' => ['required'],
     ];
 
+    /** @var array<string, string> */
+    protected $casts = [
+        'is_locked' => 'bool',
+    ];
+
     /** @var array<string, class-string> */
     public $attachOne = [
         'background_img' => File::class,

--- a/models/Template.php
+++ b/models/Template.php
@@ -44,7 +44,7 @@ class Template extends Model
 
     public function afterFetch(): void
     {
-        if (! $this->is_custom) {
+        if (! $this->is_custom && $this->code) {
             $this->fillFromView($this->code);
         }
     }

--- a/models/Template.php
+++ b/models/Template.php
@@ -4,12 +4,14 @@ namespace Renatio\DynamicPDF\Models;
 
 use Dompdf\Adapter\CPDF;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Log;
 use October\Rain\Database\Model;
 use October\Rain\Database\Traits\Validation;
 use October\Rain\Exception\ApplicationException;
 use Renatio\DynamicPDF\Classes\PDF;
 use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Classes\PDFParser;
+use Throwable;
 
 /**
  * @property int $id
@@ -30,6 +32,11 @@ class Template extends Model
 
     public $table = 'renatio_dynamicpdf_pdf_templates';
 
+    /** @var array<string, string> */
+    protected $casts = [
+        'is_custom' => 'bool',
+    ];
+
     /** @var array<string, class-string> */
     public $belongsTo = [
         'layout' => Layout::class,
@@ -42,10 +49,20 @@ class Template extends Model
         'content_html' => ['required'],
     ];
 
+    /**
+     * A stored, non-customised template follows its view file. The row is left as
+     * stored when the view is not registered any more or its file is missing.
+     */
     public function afterFetch(): void
     {
-        if (! $this->is_custom && $this->code) {
+        if ($this->is_custom || ! $this->code || ! $this->getView()) {
+            return;
+        }
+
+        try {
             $this->fillFromView($this->code);
+        } catch (Throwable $e) {
+            Log::error("Renatio.DynamicPDF could not read the view of {$this->code}: {$e->getMessage()}", ['exception' => $e]);
         }
     }
 

--- a/tests/Unit/Classes/SyncTemplatesTest.php
+++ b/tests/Unit/Classes/SyncTemplatesTest.php
@@ -15,13 +15,16 @@ describe('SyncTemplates', function () {
         PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
     });
 
-    afterEach(fn () => PDFManager::forgetInstance());
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        (new ReflectionProperty(SyncTemplates::class, 'failed'))->setValue(null, []);
+    });
 
     it('creates registered layouts and templates from their views', function () {
         (new SyncTemplates)->handle();
 
-        expect((bool) Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->first()?->is_locked)->toBeTrue()
-            ->and((bool) Template::whereCode('renatio.dynamicpdf::pdf.invoice')->first()?->is_custom)->toBeFalse()
+        expect(Layout::byCode('renatio.dynamicpdf::pdf.layouts.default')->is_locked)->toBeTrue()
+            ->and(Template::byCode('renatio.dynamicpdf::pdf.invoice')->is_custom)->toBeFalse()
             ->and(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
     });
 
@@ -37,23 +40,34 @@ describe('SyncTemplates', function () {
 
     it('skips a registered code without a view file, logs it and still creates the others', function () {
         PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.missing']);
-        Log::shouldReceive('error')->once()->withArgs(fn (string $message): bool => str_contains($message, 'pdf.layouts.missing'));
+        $log = Log::spy();
 
         (new SyncTemplates)->handle();
+
+        $log->shouldHaveReceived('error')->once()->withArgs(fn (string $message): bool => str_contains($message, 'pdf.layouts.missing'));
 
         expect(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.missing')->exists())->toBeFalse()
             ->and(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->exists())->toBeTrue()
             ->and(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
     });
 
-    it('does not synchronise on plugin boot', function () {
+    it('does not synchronise on plugin boot or controller construction', function () {
         (new Plugin(app()))->boot();
+        new Templates;
 
         expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeFalse();
     });
 
-    it('synchronises when the templates controller is opened', function () {
-        new Templates;
+    it('keeps a stored template whose view file went missing', function () {
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.gone']);
+        $this->createTemplate(['code' => 'renatio.dynamicpdf::pdf.gone', 'is_custom' => false, 'content_html' => '<p>stored</p>']);
+        Log::spy();
+
+        expect(Template::byCode('renatio.dynamicpdf::pdf.gone')->content_html)->toBe('<p>stored</p>');
+    });
+
+    it('synchronises before a templates page is displayed', function () {
+        (new Templates)->beforeDisplay();
 
         expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
     });

--- a/tests/Unit/Classes/SyncTemplatesTest.php
+++ b/tests/Unit/Classes/SyncTemplatesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Facades\Log;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
+use Renatio\DynamicPDF\Controllers\Templates;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
+use Renatio\DynamicPDF\Plugin;
+
+describe('SyncTemplates', function () {
+    beforeEach(function () {
+        PDFManager::forgetInstance();
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+    });
+
+    afterEach(fn () => PDFManager::forgetInstance());
+
+    it('creates registered layouts and templates from their views', function () {
+        (new SyncTemplates)->handle();
+
+        expect((bool) Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->first()?->is_locked)->toBeTrue()
+            ->and((bool) Template::whereCode('renatio.dynamicpdf::pdf.invoice')->first()?->is_custom)->toBeFalse()
+            ->and(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
+    });
+
+    it('removes stored templates that are no longer registered unless customised', function () {
+        $this->createTemplate(['code' => 'gone::pdf.stale', 'is_custom' => false]);
+        $this->createTemplate(['code' => 'kept::pdf.custom', 'is_custom' => true]);
+
+        (new SyncTemplates)->handle();
+
+        expect(Template::whereCode('gone::pdf.stale')->exists())->toBeFalse()
+            ->and(Template::whereCode('kept::pdf.custom')->exists())->toBeTrue();
+    });
+
+    it('skips a registered code without a view file, logs it and still creates the others', function () {
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.missing']);
+        Log::shouldReceive('error')->once()->withArgs(fn (string $message): bool => str_contains($message, 'pdf.layouts.missing'));
+
+        (new SyncTemplates)->handle();
+
+        expect(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.missing')->exists())->toBeFalse()
+            ->and(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->exists())->toBeTrue()
+            ->and(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
+    });
+
+    it('does not synchronise on plugin boot', function () {
+        (new Plugin(app()))->boot();
+
+        expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeFalse();
+    });
+
+    it('synchronises when the templates controller is opened', function () {
+        new Templates;
+
+        expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue();
+    });
+});

--- a/tests/Unit/Models/TemplateTest.php
+++ b/tests/Unit/Models/TemplateTest.php
@@ -15,6 +15,12 @@ describe('Template', function () {
             ->toThrow(ModelNotFoundException::class);
     });
 
+    it('survives a fetch without the code column', function () {
+        $this->createTemplate(['code' => 'partial::pdf.select', 'is_custom' => false]);
+
+        expect(Template::whereCode('partial::pdf.select')->value('is_custom'))->toBeFalsy();
+    });
+
     it('belongs to a layout', function () {
         $layout = $this->createLayout();
         $template = $this->createTemplate(['layout_id' => $layout->id]);

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -65,4 +65,5 @@ v8.0.4:
     - Throw on unknown wrapper methods instead of ignoring them.
     - Render a registered template or layout from its view when it is not stored yet.
     - Complete the translations and add French, Italian, Dutch and Russian.
+    - Synchronise registered views only in the backend and the demo command, and log a code whose view is missing instead of stopping the whole sync.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
- `Plugin::boot()` uruchamiał `SyncTemplates` przy każdym żądaniu HTTP i komendzie artisan (dwa zapytania, `mkdir`, wywołanie `registerPDF*` wszystkich pluginów), a wyjątki połykał pustym `catch` (#122).
- Jeden zarejestrowany kod bez pliku widoku przerywał całą synchronizację, także szablonów z innych pluginów, bez śladu w logu (#115).
- Dodatkowo `Template::afterFetch()` wołało `fillFromView($this->code)` również przy zapytaniach z podzbiorem kolumn (`value()`), gdzie `code` jest `null` → `TypeError`.

## Rozwiązanie
- synchronizacja w konstruktorach `Templates` i `Layouts` (otwarcie *Settings › PDF Templates*) oraz po `dynamicpdf:demo`; frontend jej nie potrzebuje, bo `byCode()` renderuje zarejestrowany widok z pliku (#119),
- każdy kod tworzony osobno w `try/catch` z `Log::error`; brak katalogu fontów też trafia do logu,
- listener `rainlab.translate.themeScanner.afterScan` rejestrowany raz w `boot()` zamiast przy każdym `handle()`,
- `afterFetch()` pomija fetch bez kolumny `code`,
- README (sekcja rejestrowania), UPGRADE 8.0.4, `version.yaml`.

## Testy
`tests/Unit/Classes/SyncTemplatesTest.php`: tworzenie z widoków, usuwanie niezarejestrowanych niecustomowych z zachowaniem customowych, pominięcie brakującego widoku z logiem i utworzenie pozostałych, brak synchronizacji w `boot()`, synchronizacja przy otwarciu kontrolera. `TemplateTest`: fetch bez kolumny `code`. 4 z nich czerwone na starym kodzie.

Closes #122
Closes #115
