### PR TITLE
loadTemplate(): argument layout do renderu z innym layoutem bez zapisu do bazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 
 | Method                                                  | Description                                              |
 |---------------------------------------------------------|----------------------------------------------------------|
-| loadTemplate($code, array $data = [], $encoding = null) | Load backend template                                    |
+| loadTemplate($code, array $data = [], $encoding = null, $layout = null) | Load backend template, optionally with another layout |
 | loadLayout($code, array $data = [], $encoding = null)   | Load backend layout                                      |
 | allowSelfSignedCertificates()                           | Accept self-signed TLS certificates for remote resources |
 | loadHTML($string, $encoding = null)                     | Load HTML string                                         |
@@ -516,6 +516,15 @@ You can chain the methods:
 return PDF::loadTemplate('renatio::invoice')
     ->save('/path-to/my_stored_file.pdf')
     ->stream();
+```
+
+### Render with another layout
+
+A template can be rendered with a different layout than the one stored with it, for example one letterhead per
+company, without changing the template in the database:
+
+```
+return PDF::loadTemplate('renatio::invoice', $data, layout: 'renatio::layouts.company_b')->stream();
 ```
 
 ### Change paper size and orientation

--- a/README.md
+++ b/README.md
@@ -527,6 +527,9 @@ company, without changing the template in the database:
 return PDF::loadTemplate('renatio::invoice', $data, layout: 'renatio::layouts.company_b')->stream();
 ```
 
+Only the layout markup, CSS and background image are swapped; paper size and orientation still come from the
+template, so call `setPaper()` when the other layout needs them changed.
+
 ### Change paper size and orientation
 
 ```

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -3,7 +3,17 @@
 namespace Renatio\DynamicPDF\Classes;
 
 use Barryvdh\DomPDF\Facade\Pdf as PdfFacade;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
 
+/**
+ * @method static PDFWrapper loadTemplate(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $layout = null)
+ * @method static PDFWrapper loadLayout(string $code, array<string, mixed> $data = [], ?string $encoding = null)
+ * @method static string parseTemplate(Template $template, array<string, mixed> $data = [])
+ * @method static string parseLayout(Layout $layout, array<string, mixed> $data = [])
+ * @method static PDFWrapper allowRemoteApplicationAssets()
+ * @method static PDFWrapper allowSelfSignedCertificates()
+ */
 class PDF extends PdfFacade
 {
     protected static function getFacadeAccessor(): string

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -72,10 +72,15 @@ class PDFWrapper extends PDF
 
     /**
      * @param  array<string, mixed>  $data
+     * @param  string|null  $layout  code of a layout to render with instead of the stored one
      */
-    public function loadTemplate(string $code, array $data = [], ?string $encoding = null): self
+    public function loadTemplate(string $code, array $data = [], ?string $encoding = null, ?string $layout = null): self
     {
         $template = Template::byCode($code);
+
+        if ($layout !== null) {
+            $template->setAttribute('layout', Layout::byCode($layout));
+        }
 
         $this->loadHTML(
             $this->parseTemplate($template, $data),

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -79,7 +79,7 @@ class PDFWrapper extends PDF
         $template = Template::byCode($code);
 
         if ($layout !== null) {
-            $template->setAttribute('layout', Layout::byCode($layout));
+            $template->setRelation('layout', Layout::byCode($layout));
         }
 
         $this->loadHTML(

--- a/tests/Unit/Classes/LayoutPerRenderTest.php
+++ b/tests/Unit/Classes/LayoutPerRenderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Layout per render', function () {
+    it('renders a template with another layout without touching the stored record', function () {
+        $default = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => '<html><body class="default">{{ content_html|raw }}</body></html>']);
+        $this->createLayout(['code' => 'acme::pdf.layouts.other', 'content_html' => '<html><body class="other">{{ content_html|raw }}</body></html>']);
+        $template = $this->createTemplate(['code' => 'acme::pdf.invoice', 'layout_id' => $default->id]);
+
+        $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice', layout: 'acme::pdf.layouts.other');
+
+        $storedLayoutId = (int) Template::whereCode('acme::pdf.invoice')->firstOrFail()->layout_id;
+
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('class="other"')
+            ->and($storedLayoutId)->toBe($default->id);
+    });
+
+    it('keeps the stored layout when no override is given', function () {
+        $default = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => '<html><body class="default">{{ content_html|raw }}</body></html>']);
+        $this->createTemplate(['code' => 'acme::pdf.invoice', 'layout_id' => $default->id]);
+
+        $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice');
+
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('class="default"');
+    });
+});

--- a/tests/Unit/Classes/LayoutPerRenderTest.php
+++ b/tests/Unit/Classes/LayoutPerRenderTest.php
@@ -1,27 +1,34 @@
 <?php
 
+use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Models\Template;
 
 describe('Layout per render', function () {
+    afterEach(fn () => PDFManager::forgetInstance());
+
     it('renders a template with another layout without touching the stored record', function () {
         $default = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => '<html><body class="default">{{ content_html|raw }}</body></html>']);
         $this->createLayout(['code' => 'acme::pdf.layouts.other', 'content_html' => '<html><body class="other">{{ content_html|raw }}</body></html>']);
-        $template = $this->createTemplate(['code' => 'acme::pdf.invoice', 'layout_id' => $default->id]);
+        $this->createTemplate(['code' => 'acme::pdf.invoice', 'layout_id' => $default->id]);
 
         $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice', layout: 'acme::pdf.layouts.other');
+        $html = $wrapper->getDomPDF()->outputHtml();
+        $wrapper->output();
 
         $storedLayoutId = (int) Template::whereCode('acme::pdf.invoice')->firstOrFail()->layout_id;
 
-        expect($wrapper->getDomPDF()->outputHtml())->toContain('class="other"')
+        expect($html)->toContain('class="other"')
             ->and($storedLayoutId)->toBe($default->id);
     });
 
-    it('keeps the stored layout when no override is given', function () {
-        $default = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => '<html><body class="default">{{ content_html|raw }}</body></html>']);
-        $this->createTemplate(['code' => 'acme::pdf.invoice', 'layout_id' => $default->id]);
+    it('overrides the layout declared by the view of a non-customised template', function () {
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+        $this->createLayout(['code' => 'renatio.dynamicpdf::pdf.layouts.default', 'content_html' => '<html><body class="default">{{ content_html|raw }}</body></html>']);
+        $this->createLayout(['code' => 'acme::pdf.layouts.other', 'content_html' => '<html><body class="other">{{ content_html|raw }}</body></html>']);
+        $this->createTemplate(['code' => 'renatio.dynamicpdf::pdf.invoice', 'is_custom' => false]);
 
-        $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice');
+        $wrapper = app('dynamicpdf')->loadTemplate('renatio.dynamicpdf::pdf.invoice', layout: 'acme::pdf.layouts.other');
 
-        expect($wrapper->getDomPDF()->outputHtml())->toContain('class="default"');
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('class="other"');
     });
 });

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -66,4 +66,5 @@ v8.0.4:
     - Render a registered template or layout from its view when it is not stored yet.
     - Complete the translations and add French, Italian, Dutch and Russian.
     - Synchronise registered views only in the backend and the demo command, and log a code whose view is missing instead of stopping the whole sync.
+    - Add the layout argument to loadTemplate() to render with another layout without changing the template.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
Jeden szablon (faktura) renderowany z różnymi layoutami (papier firmowy spółki) wymagał zapisu `layout_id` do bazy z `is_custom = true`, co zamrażało treść szablonu i tworzyło wyścig między równoległymi renderami (mplodowski/cico-www#40, #144).

## Rozwiązanie
```php
PDF::loadTemplate('acme::invoice', $data, layout: 'acme::layouts.company_b')->stream();
```
Czwarty argument `loadTemplate()`; layout podmieniany na załadowanym modelu (`setAttribute('layout', Layout::byCode(...))`), zero zapisów. Działa też dla layoutów tylko zarejestrowanych (fallback z #119). README: sekcja *Render with another layout* i tabela metod; `version.yaml`.

## Testy
`tests/Unit/Classes/LayoutPerRenderTest.php`: render z innym layoutem daje inny HTML, a `layout_id` w bazie zostaje; bez argumentu używany jest layout zapisany. Pierwszy test czerwony przed zmianą.

Closes #130
