### PR TITLE
README dla dompdf 3, sekcja Requirements, brakujące wpisy w UPGRADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,9 @@ The options most often changed are `dpi`, `default_font`, `default_paper_size`, 
 required for images, stylesheets and fonts loaded by URL), `allowed_remote_hosts`, `chroot` and `font_dir`. The full
 list with the current defaults is in the published `config/dompdf.php` and in
 [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php); every option has a matching
-`set*()` method on the wrapper.
+`set*()` method on the wrapper named after the camel-cased key, except the `enable_*` options, which are
+`setIsRemoteEnabled()`, `setIsPhpEnabled()`, `setIsJavascriptEnabled()`, `setIsHtml5ParserEnabled()` and
+`setIsFontSubsettingEnabled()`.
 
 ### Self-signed certificates
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ HTML to PDF converter uses [dompdf](https://github.com/dompdf/dompdf) library.
 
 Plugin uses dompdf wrapper for Laravel [barryvdh/laravel-dompdf](https://github.com/barryvdh/laravel-dompdf).
 
+## Requirements
+
+This plugin requires PHP 8.2 or higher and October CMS 4.0 or higher. Running its test suite and static analysis
+needs PHP 8.4.
+
+Templates are rendered with Twig without a sandbox, so the `Manage templates` and `Manage layouts` permissions
+should only be granted to trusted users.
+
 ## Like this plugin?
 
 If you like this plugin, give this plugin a Like or Make donation with [PayPal](https://www.paypal.me/mplodowski).
@@ -257,36 +265,11 @@ PDF::loadTemplate('renatio::invoice')
     ->stream();
 ```
 
-Available options and their defaults:
-
-* __rootDir__: "{app_directory}/vendor/dompdf/dompdf"
-* __tempDir__: "/tmp" _(available in config/dompdf.php)_
-* __fontDir__: "{app_directory}/storage/fonts/" _(available in config/dompdf.php)_
-* __fontCache__: "{app_directory}/storage/fonts/" _(available in config/dompdf.php)_
-* __chroot__: "{app_directory}" _(available in config/dompdf.php)_
-* __logOutputFile__: "/tmp/log.htm"
-* __defaultMediaType__: "screen" _(available in config/dompdf.php)_
-* __defaultPaperSize__: "a4" _(available in config/dompdf.php)_
-* __defaultFont__: "serif" _(available in config/dompdf.php)_
-* __dpi__: 96 _(available in config/dompdf.php)_
-* __fontHeightRatio__: 1.1 _(available in config/dompdf.php)_
-* __isPhpEnabled__: false _(available in config/dompdf.php)_
-* __isRemoteEnabled__: true _(available in config/dompdf.php)_
-* __isJavascriptEnabled__: true _(available in config/dompdf.php)_
-* __isHtml5ParserEnabled__: false _(available in config/dompdf.php)_
-* __isFontSubsettingEnabled__: false _(available in config/dompdf.php)_
-* __debugPng__: false
-* __debugKeepTemp__: false
-* __debugCss__: false
-* __debugLayout__: false
-* __debugLayoutLines__: true
-* __debugLayoutBlocks__: true
-* __debugLayoutInline__: true
-* __debugLayoutPaddingBox__: true
-* __pdfBackend__: "CPDF" _(available in config/dompdf.php)_
-* __pdflibLicense__: ""
-
-See [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php) for a list of available options.
+The options most often changed are `dpi`, `default_font`, `default_paper_size`, `enable_remote` (off by default;
+required for images, stylesheets and fonts loaded by URL), `allowed_remote_hosts`, `chroot` and `font_dir`. The full
+list with the current defaults is in the published `config/dompdf.php` and in
+[Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php); every option has a matching
+`set*()` method on the wrapper.
 
 ### Self-signed certificates
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,12 +62,15 @@ Drop support for October CMS version 2.x.
 
 ## Upgrading To 7.0.0
 
-Plugin requires Laravel Dompdf v2 and dompdf 2. The `setOptions()` method now replaces the whole options object; use
-the dynamic `set*()` methods or `setOption()` to change single options.
+Plugin requires Laravel Dompdf v2 and dompdf 2. `setOptions()` is deprecated and still replaces the whole options
+object, as noted for 4.0.8; the new `setOption()` changes a single option and the dynamic `set*()` methods keep
+working.
 
 ## Upgrading To 8.0.1
 
-Plugin requires October CMS 4.0 or higher.
+Plugin adds support for October CMS 4.0 while keeping 3.x, and upgrades to Laravel Dompdf v3 and dompdf 3. Options
+removed by dompdf 3 (for example `enable_css_float` and `setAdminUsername()`) no longer apply, and the HTML5 parser is
+always on.
 
 ## Upgrading To 8.0.4
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -60,6 +60,15 @@ Plugin requires October CMS version 3.0 or higher, Laravel 9.0 or higher and PHP
 
 Drop support for October CMS version 2.x.
 
+## Upgrading To 7.0.0
+
+Plugin requires Laravel Dompdf v2 and dompdf 2. The `setOptions()` method now replaces the whole options object; use
+the dynamic `set*()` methods or `setOption()` to change single options.
+
+## Upgrading To 8.0.1
+
+Plugin requires October CMS 4.0 or higher.
+
 ## Upgrading To 8.0.4
 
 **Security release. Upgrade every installation running 8.0.x.** Plugin requires PHP 8.2 or higher and October CMS 4.0


### PR DESCRIPTION
## Zakres
**README**
- lista opcji dompdf (przestarzała: `isHtml5ParserEnabled`, `pdflibLicense`, `isRemoteEnabled: true` jako domyślne) zastąpiona krótkim opisem najczęściej zmienianych opcji z odesłaniem do opublikowanego `config/dompdf.php` i `Dompdf\Options`,
- sekcja *Requirements* (PHP 8.2, October 4, PHP 8.4 do testów) jak w pozostałych pluginach,
- nota o tym, że Twig w szablonach nie jest sandboxowany, więc uprawnienia do szablonów tylko dla zaufanych użytkowników,
- Demo URL zostaje: instancja odpowiada 200 (sprawdzone 2026-09-07).

**UPGRADE.md**
- brakujące sekcje 7.0.0 (Laravel Dompdf v2, `setOptions()` zastępuje całość opcji) i 8.0.1 (October 4).

Kotwica `#configuration` i sekcja 8.0.4 były już poprawione w #138.

Closes #124
Closes #125
