### PR TITLE
loadTemplate()/loadLayout(): argument locale z przywróceniem poprzedniego języka

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 
 | Method                                                  | Description                                              |
 |---------------------------------------------------------|----------------------------------------------------------|
-| loadTemplate($code, array $data = [], $encoding = null, $layout = null) | Load backend template, optionally with another layout |
-| loadLayout($code, array $data = [], $encoding = null)   | Load backend layout                                      |
+| loadTemplate($code, array $data = [], $encoding = null, $layout = null, $locale = null) | Load backend template, optionally with another layout and locale |
+| loadLayout($code, array $data = [], $encoding = null, $locale = null) | Load backend layout, optionally in another locale |
 | allowSelfSignedCertificates()                           | Accept self-signed TLS certificates for remote resources |
 | loadHTML($string, $encoding = null)                     | Load HTML string                                         |
 | loadFile($file)                                         | Load HTML string from a file                             |
@@ -529,6 +529,16 @@ return PDF::loadTemplate('renatio::invoice', $data, layout: 'renatio::layouts.co
 
 Only the layout markup, CSS and background image are swapped; paper size and orientation still come from the
 template, so call `setPaper()` when the other layout needs them changed.
+
+### Render in another language
+
+The document language usually should not depend on the language of the backend user who generated it. Pass the
+locale to render in; translations, dates and the `locale` template variable follow it, and the application locale is
+restored afterwards, also when rendering fails:
+
+```
+return PDF::loadTemplate('renatio::invoice', $data, locale: 'de')->download('rechnung.pdf');
+```
 
 ### Change paper size and orientation
 

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -7,8 +7,8 @@ use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 
 /**
- * @method static PDFWrapper loadTemplate(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $layout = null)
- * @method static PDFWrapper loadLayout(string $code, array<string, mixed> $data = [], ?string $encoding = null)
+ * @method static PDFWrapper loadTemplate(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $layout = null, ?string $locale = null)
+ * @method static PDFWrapper loadLayout(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $locale = null)
  * @method static string parseTemplate(Template $template, array<string, mixed> $data = [])
  * @method static string parseLayout(Layout $layout, array<string, mixed> $data = [])
  * @method static PDFWrapper allowRemoteApplicationAssets()

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -73,8 +73,9 @@ class PDFWrapper extends PDF
     /**
      * @param  array<string, mixed>  $data
      * @param  string|null  $layout  code of a layout to render with instead of the stored one
+     * @param  string|null  $locale  language to render in, restored afterwards
      */
-    public function loadTemplate(string $code, array $data = [], ?string $encoding = null, ?string $layout = null): self
+    public function loadTemplate(string $code, array $data = [], ?string $encoding = null, ?string $layout = null, ?string $locale = null): self
     {
         $template = Template::byCode($code);
 
@@ -83,7 +84,7 @@ class PDFWrapper extends PDF
         }
 
         $this->loadHTML(
-            $this->parseTemplate($template, $data),
+            $this->inLocale($locale, fn (array $data): string => $this->parseTemplate($template, $data), $data),
             $encoding,
         );
 
@@ -96,11 +97,14 @@ class PDFWrapper extends PDF
 
     /**
      * @param  array<string, mixed>  $data
+     * @param  string|null  $locale  language to render in, restored afterwards
      */
-    public function loadLayout(string $code, array $data = [], ?string $encoding = null): self
+    public function loadLayout(string $code, array $data = [], ?string $encoding = null, ?string $locale = null): self
     {
+        $layout = Layout::byCode($code);
+
         $this->loadHTML(
-            $this->parseLayout(Layout::byCode($code), $data),
+            $this->inLocale($locale, fn (array $data): string => $this->parseLayout($layout, $data), $data),
             $encoding,
         );
 
@@ -133,6 +137,29 @@ class PDFWrapper extends PDF
             $layout->content_html,
             $this->layoutData($layout, $data),
         );
+    }
+
+    /**
+     * Twig, the translator and Carbon all read the application locale, so it is switched
+     * for the render only and always put back, also when the render throws.
+     *
+     * @param  callable(array<string, mixed>): string  $render
+     * @param  array<string, mixed>  $data
+     */
+    protected function inLocale(?string $locale, callable $render, array $data): string
+    {
+        if ($locale === null) {
+            return $render($data);
+        }
+
+        $previous = app()->getLocale();
+        app()->setLocale($locale);
+
+        try {
+            return $render(array_merge(['locale' => $locale], $data));
+        } finally {
+            app()->setLocale($previous);
+        }
     }
 
     /**

--- a/tests/Unit/Classes/LocalePerRenderTest.php
+++ b/tests/Unit/Classes/LocalePerRenderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Twig\Error\SyntaxError;
+
+describe('Locale per render', function () {
+    it('renders a template in the given locale and restores the previous one', function () {
+        app()->setLocale('en');
+        $this->createTemplate(['code' => 'acme::pdf.invoice', 'content_html' => "{{ 'backend::lang.form.save'|trans }} {{ locale }}"]);
+
+        $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice', locale: 'pl');
+
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('Zapisz pl')
+            ->and(app()->getLocale())->toBe('en');
+    });
+
+    it('restores the previous locale when rendering fails', function () {
+        app()->setLocale('en');
+        $this->createTemplate(['code' => 'acme::pdf.broken', 'content_html' => '{{ name']);
+
+        expect(fn () => app('dynamicpdf')->loadTemplate('acme::pdf.broken', locale: 'pl'))->toThrow(SyntaxError::class)
+            ->and(app()->getLocale())->toBe('en');
+    });
+
+    it('renders a layout in the given locale', function () {
+        app()->setLocale('en');
+        $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => "<html><body>{{ 'backend::lang.form.save'|trans }}</body></html>"]);
+
+        $wrapper = app('dynamicpdf')->loadLayout('acme::pdf.layouts.default', locale: 'de');
+
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('Speichern')
+            ->and(app()->getLocale())->toBe('en');
+    });
+});

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -67,4 +67,5 @@ v8.0.4:
     - Complete the translations and add French, Italian, Dutch and Russian.
     - Synchronise registered views only in the backend and the demo command, and log a code whose view is missing instead of stopping the whole sync.
     - Add the layout argument to loadTemplate() to render with another layout without changing the template.
+    - Add the locale argument to loadTemplate() and loadLayout() to render in another language and restore the previous one.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
Język dokumentu zależał od `app()->getLocale()` w chwili renderu, czyli od języka panelu osoby, która kliknęła. Projekty musiały pamiętać o `app()->setLocale()` przed każdym `loadTemplate()` i przywrócić je po (mplodowski/cico-www#141: 36 akcji, część bez ustawienia locale).

## Rozwiązanie
```php
PDF::loadTemplate('acme::invoice', $data, locale: 'de')->download('rechnung.pdf');
PDF::loadLayout('acme::layouts.default', locale: 'pl');
```
`inLocale()` przełącza locale aplikacji na czas parsowania (tłumaczenia, daty), dokłada zmienną `locale` do danych szablonu i przywraca poprzednie w `finally`. Bez argumentu zachowanie bez zmian. README (sekcja *Render in another language*, tabela metod), `@method` na fasadzie, `version.yaml`.

## Testy
`tests/Unit/Classes/LocalePerRenderTest.php`: `trans` w szablonie w `pl`, `locale` w danych, przywrócenie `en` po renderze i po wyjątku Twig, layout w `de`. Czerwone przed zmianą (nieznany argument nazwany).

Closes #131
