### PR TITLE
pageNumbers(): numeracja stron bez inline PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,9 @@ return PDF::loadTemplate('renatio::invoice')
 ```
 
 `{PAGE_NUM}` and `{PAGE_COUNT}` are replaced on each page. Positions: `top-left`, `top-center`, `top-right`,
-`bottom-left`, `bottom-center`, `bottom-right`; `font`, `margin` (points) and `color` (RGB between 0 and 1) are
-optional.
+`bottom-left`, `bottom-center`, `bottom-right`; `font` (a family available in the document, for example one declared
+with `@font-face` in the layout; the dompdf default font otherwise), `margin` (points) and `color` (RGB between 0
+and 1) are optional. Requires the CPDF or PDFLib backend; the GD backend cannot draw page text.
 
 Inline PHP (`setIsPhpEnabled(true)`) is no longer needed for page numbers and should stay off.
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 |---------------------------------------------------------|----------------------------------------------------------|
 | loadTemplate($code, array $data = [], $encoding = null, $layout = null, $locale = null) | Load backend template, optionally with another layout and locale |
 | loadLayout($code, array $data = [], $encoding = null, $locale = null) | Load backend layout, optionally in another locale |
+| loadTemplate($code, array $data = [], $encoding = null, $layout = null) | Load backend template, optionally with another layout |
+| loadLayout($code, array $data = [], $encoding = null)   | Load backend layout                                      |
+| pageNumbers($text, $position, $size, $font, $margin, $color) | Stamp page numbers on every page                    |
 | allowSelfSignedCertificates()                           | Accept self-signed TLS certificates for remote resources |
 | loadHTML($string, $encoding = null)                     | Load HTML string                                         |
 | loadFile($file)                                         | Load HTML string from a file                             |
@@ -398,50 +401,23 @@ Recommended approach is to save PDF file locally and return redirect to PDF file
 
 ### Page numbers
 
-Page numbers can be generated using PHP. Inline PHP is disabled by default, because it can be a security risk. You can
-enable inline PHP using `setIsPhpEnabled` method.
-
-> **Security warning:** only enable `setIsPhpEnabled(true)` when the template content is fully trusted. Any
-> `<script type="text/php">` block in the HTML is executed on the server, so enabling it for templates that can be
-> edited by backend users allows remote code execution. For this reason the backend HTML and PDF preview no longer
-> enables inline PHP, and the bundled demo layout no longer ships a page number script.
+Page numbers are stamped on every page after rendering, without enabling inline PHP:
 
 ```
 return PDF::loadTemplate('renatio::invoice')
-    ->setIsRemoteEnabled(true)
-    ->setIsPhpEnabled(true)
+    ->pageNumbers('Page {PAGE_NUM} of {PAGE_COUNT}', position: 'bottom-center', size: 9)
     ->stream();
 ```
 
-After that you must place following code before closing `</body>` tag of the layout file.
+`{PAGE_NUM}` and `{PAGE_COUNT}` are replaced on each page. Positions: `top-left`, `top-center`, `top-right`,
+`bottom-left`, `bottom-center`, `bottom-right`; `font`, `margin` (points) and `color` (RGB between 0 and 1) are
+optional.
 
-```
-<script type="text/php">
-    if (isset($pdf)) {
-        $size = 9;
-        $color = [0,0,0];
+Inline PHP (`setIsPhpEnabled(true)`) is no longer needed for page numbers and should stay off.
 
-        $font = $fontMetrics->getFont('Open Sans');
-        $textHeight = $fontMetrics->getFontHeight($font, $size);
-        $width = $fontMetrics->getTextWidth('Page 1 of 2', $font, $size);
-
-        $foot = $pdf->open_object();
-
-        $w = $pdf->get_width();
-        $h = $pdf->get_height();
-
-        $y = $h - $textHeight - 13;
-
-        $pdf->close_object();
-        $pdf->add_object($foot, 'all');
-
-        $text = "Page {PAGE_NUM} of {PAGE_COUNT}";
-
-        // Center the text
-        $pdf->page_text($w / 2 - $width / 2, $y, $text, $font, $size, $color);
-    }
-</script>
-```
+> **Security warning:** only enable `setIsPhpEnabled(true)` when the template content is fully trusted. Any
+> `<script type="text/php">` block in the HTML is executed on the server, so enabling it for templates that can be
+> edited by backend users allows remote code execution. The backend HTML and PDF preview never enables it.
 
 ## Examples
 

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -11,6 +11,7 @@ use Renatio\DynamicPDF\Models\Template;
  * @method static PDFWrapper loadLayout(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $locale = null)
  * @method static string parseTemplate(Template $template, array<string, mixed> $data = [])
  * @method static string parseLayout(Layout $layout, array<string, mixed> $data = [])
+ * @method static PDFWrapper pageNumbers(string $text = 'Page {PAGE_NUM} of {PAGE_COUNT}', string $position = 'bottom-center', float $size = 9, ?string $font = null, float $margin = 20, array<int, float> $color = [0, 0, 0])
  * @method static PDFWrapper allowRemoteApplicationAssets()
  * @method static PDFWrapper allowSelfSignedCertificates()
  */

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -33,6 +33,8 @@ class PDFWrapper extends PDF
     /** @var array{text: string, position: string, size: float, font: string|null, margin: float, color: array<int, float>}|null */
     protected ?array $pageNumbers = null;
 
+    protected bool $pageNumbersStamped = false;
+
     public function __construct(Dompdf $dompdf, ConfigRepository $config, Filesystem $files, ViewFactory $view)
     {
         parent::__construct($dompdf, $config, $files, $view);
@@ -71,17 +73,34 @@ class PDFWrapper extends PDF
             throw new InvalidArgumentException("Unknown page numbers position [{$position}].");
         }
 
+        if (count($color) !== 3 || array_filter($color, fn (float $c): bool => $c < 0 || $c > 1) !== []) {
+            throw new InvalidArgumentException('Page numbers color must be three RGB components between 0 and 1.');
+        }
+
         $this->pageNumbers = compact('text', 'position', 'size', 'font', 'margin', 'color');
 
         return $this;
     }
 
+    public function loadHTML(string $string, ?string $encoding = null): self
+    {
+        $this->pageNumbersStamped = false;
+        parent::loadHTML($string, $encoding);
+
+        return $this;
+    }
+
+    /**
+     * Stamping appends to the page streams, so a second render() (setEncryption() calls it
+     * unguarded) must not stamp again.
+     */
     public function render(): void
     {
         parent::render();
 
-        if ($this->pageNumbers !== null) {
+        if ($this->pageNumbers !== null && ! $this->pageNumbersStamped) {
             $this->stampPageNumbers($this->pageNumbers);
+            $this->pageNumbersStamped = true;
         }
     }
 
@@ -92,8 +111,14 @@ class PDFWrapper extends PDF
     {
         $canvas = $this->dompdf->getCanvas();
         $metrics = $this->dompdf->getFontMetrics();
-        $font = $metrics->getFont($numbers['font'] ?? $this->dompdf->getOptions()->getDefaultFont());
+        $font = $metrics->getFont($numbers['font']);
+
+        if ($font === null) {
+            throw new InvalidArgumentException("Font [{$numbers['font']}] is not available in the rendered document.");
+        }
+
         $pages = (string) $canvas->get_page_count();
+        // One page_text() call serves every page, so the widest text (the last page) sets the position.
         $sample = str_replace(['{PAGE_NUM}', '{PAGE_COUNT}'], [$pages, $pages], $numbers['text']);
         $width = $metrics->getTextWidth($sample, $font, $numbers['size']);
         $height = $metrics->getFontHeight($font, $numbers['size']);

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\SiteManager;
@@ -27,6 +28,11 @@ use UnexpectedValueException;
  */
 class PDFWrapper extends PDF
 {
+    public const PAGE_NUMBERS_POSITIONS = ['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'];
+
+    /** @var array{text: string, position: string, size: float, font: string|null, margin: float, color: array<int, float>}|null */
+    protected ?array $pageNumbers = null;
+
     public function __construct(Dompdf $dompdf, ConfigRepository $config, Filesystem $files, ViewFactory $view)
     {
         parent::__construct($dompdf, $config, $files, $view);
@@ -45,6 +51,62 @@ class PDFWrapper extends PDF
         $this->applyCertificatePolicy();
 
         return $this;
+    }
+
+    /**
+     * Page numbers are stamped on the canvas after rendering, so no inline PHP has to be
+     * enabled for them. {PAGE_NUM} and {PAGE_COUNT} are replaced by dompdf on every page.
+     *
+     * @param  array<int, float>  $color  RGB components between 0 and 1
+     */
+    public function pageNumbers(
+        string $text = 'Page {PAGE_NUM} of {PAGE_COUNT}',
+        string $position = 'bottom-center',
+        float $size = 9,
+        ?string $font = null,
+        float $margin = 20,
+        array $color = [0, 0, 0],
+    ): self {
+        if (! in_array($position, self::PAGE_NUMBERS_POSITIONS, true)) {
+            throw new InvalidArgumentException("Unknown page numbers position [{$position}].");
+        }
+
+        $this->pageNumbers = compact('text', 'position', 'size', 'font', 'margin', 'color');
+
+        return $this;
+    }
+
+    public function render(): void
+    {
+        parent::render();
+
+        if ($this->pageNumbers !== null) {
+            $this->stampPageNumbers($this->pageNumbers);
+        }
+    }
+
+    /**
+     * @param  array{text: string, position: string, size: float, font: string|null, margin: float, color: array<int, float>}  $numbers
+     */
+    protected function stampPageNumbers(array $numbers): void
+    {
+        $canvas = $this->dompdf->getCanvas();
+        $metrics = $this->dompdf->getFontMetrics();
+        $font = $metrics->getFont($numbers['font'] ?? $this->dompdf->getOptions()->getDefaultFont());
+        $pages = (string) $canvas->get_page_count();
+        $sample = str_replace(['{PAGE_NUM}', '{PAGE_COUNT}'], [$pages, $pages], $numbers['text']);
+        $width = $metrics->getTextWidth($sample, $font, $numbers['size']);
+        $height = $metrics->getFontHeight($font, $numbers['size']);
+        [$vertical, $horizontal] = explode('-', $numbers['position']);
+
+        $x = match ($horizontal) {
+            'left' => $numbers['margin'],
+            'center' => ($canvas->get_width() - $width) / 2,
+            default => $canvas->get_width() - $numbers['margin'] - $width,
+        };
+        $y = $vertical === 'top' ? $numbers['margin'] : $canvas->get_height() - $numbers['margin'] - $height;
+
+        $canvas->page_text($x, $y, $numbers['text'], $font, $numbers['size'], $numbers['color']);
     }
 
     public function __call($method, $parameters)

--- a/tests/Unit/Classes/PageNumbersTest.php
+++ b/tests/Unit/Classes/PageNumbersTest.php
@@ -1,0 +1,22 @@
+<?php
+
+describe('Page numbers', function () {
+    it('stamps page numbers on every page without inline PHP', function () {
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>one</p><p style="page-break-before: always;">two</p>');
+        $wrapper->pageNumbers('Page {PAGE_NUM} of {PAGE_COUNT}');
+
+        $pdf = $wrapper->output(['compress' => 0]);
+
+        expect($wrapper->getDomPDF()->getOptions()->getIsPhpEnabled())->toBeFalse()
+            ->and($pdf)->toContain('Page 1 of 2')
+            ->and($pdf)->toContain('Page 2 of 2');
+    });
+
+    it('renders without page numbers by default', function () {
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>one</p>');
+
+        expect($wrapper->output(['compress' => 0]))->not->toContain('Page 1 of 1');
+    });
+});

--- a/tests/Unit/Classes/PageNumbersTest.php
+++ b/tests/Unit/Classes/PageNumbersTest.php
@@ -1,9 +1,16 @@
 <?php
 
 describe('Page numbers', function () {
-    it('stamps page numbers on every page without inline PHP', function () {
+    $twoPages = function (): \Renatio\DynamicPDF\Classes\PDFWrapper {
         $wrapper = app('dynamicpdf');
+        $wrapper->setOption(['defaultFont' => 'serif', 'pdfBackend' => 'CPDF']);
         $wrapper->loadHTML('<p>one</p><p style="page-break-before: always;">two</p>');
+
+        return $wrapper;
+    };
+
+    it('stamps page numbers on every page without inline PHP', function () use ($twoPages) {
+        $wrapper = $twoPages();
         $wrapper->pageNumbers('Page {PAGE_NUM} of {PAGE_COUNT}');
 
         $pdf = $wrapper->output(['compress' => 0]);
@@ -13,10 +20,28 @@ describe('Page numbers', function () {
             ->and($pdf)->toContain('Page 2 of 2');
     });
 
-    it('renders without page numbers by default', function () {
-        $wrapper = app('dynamicpdf');
-        $wrapper->loadHTML('<p>one</p>');
+    it('stamps once even when the document is rendered again', function () use ($twoPages) {
+        $wrapper = $twoPages();
+        $wrapper->pageNumbers('Page {PAGE_NUM} of {PAGE_COUNT}');
+        $wrapper->render();
+        $wrapper->render();
 
-        expect($wrapper->output(['compress' => 0]))->not->toContain('Page 1 of 1');
+        expect(substr_count($wrapper->output(['compress' => 0]), 'Page 1 of 2'))->toBe(1);
+    });
+
+    it('rejects a font the document does not know', function () use ($twoPages) {
+        $wrapper = $twoPages();
+        $wrapper->pageNumbers('Page {PAGE_NUM}', font: 'No Such Family');
+
+        expect(fn () => $wrapper->output())->toThrow(InvalidArgumentException::class);
+    });
+
+    it('rejects a colour outside the 0..1 range', function () {
+        expect(fn () => app('dynamicpdf')->pageNumbers('Page {PAGE_NUM}', color: [255, 0, 0]))
+            ->toThrow(InvalidArgumentException::class);
+    });
+
+    it('renders without page numbers by default', function () use ($twoPages) {
+        expect($twoPages()->output(['compress' => 0]))->not->toContain('Page 1 of 2');
     });
 });

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -68,4 +68,5 @@ v8.0.4:
     - Synchronise registered views only in the backend and the demo command, and log a code whose view is missing instead of stopping the whole sync.
     - Add the layout argument to loadTemplate() to render with another layout without changing the template.
     - Add the locale argument to loadTemplate() and loadLayout() to render in another language and restore the previous one.
+    - Add pageNumbers() to stamp page numbers without inline PHP.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
Numeracja stron była jedynym powodem włączania `isPhpEnabled` (RCE dla każdego edytującego szablony). Po 8.0.4 plugin nie dawał bezpiecznej alternatywy.

## Rozwiązanie
```php
PDF::loadTemplate('acme::invoice')->pageNumbers('Page {PAGE_NUM} of {PAGE_COUNT}', position: 'bottom-center', size: 9)->stream();
```
`pageNumbers()` zapisuje konfigurację, a nadpisany `render()` po renderze stempluje tekst przez `Canvas::page_text()` (dompdf podstawia `{PAGE_NUM}`/`{PAGE_COUNT}` na każdej stronie). Pozycje `top-*`/`bottom-*` × `left|center|right`, opcjonalnie font, margines i kolor. README: sekcja *Page numbers* przepisana (bez `<script type="text/php">`), tabela metod, `@method` na fasadzie, `version.yaml`.

## Testy
`tests/Unit/Classes/PageNumbersTest.php`: dwustronicowy PDF (bez kompresji) zawiera „Page 1 of 2” i „Page 2 of 2” przy wyłączonym inline PHP; domyślnie brak numeracji. Czerwony przed zmianą (`UnexpectedValueException` z `__call`).

Closes #132
