### PR TITLE
Lista szablonów: jedno zapytanie o layout na kod zamiast na wiersz

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace Renatio\DynamicPDF;
 
+use ArrayObject;
 use Backend\Facades\Backend;
 use Barryvdh\DomPDF\ServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
@@ -63,6 +64,8 @@ class Plugin extends PluginBase
 
     public function register(): void
     {
+        $this->app->scoped(Template::LAYOUT_CACHE, fn (): ArrayObject => new ArrayObject);
+
         $this->registerConsoleCommand('dynamicpdf:demo', Demo::class);
     }
 

--- a/console/Demo.php
+++ b/console/Demo.php
@@ -44,7 +44,7 @@ class Demo extends Command
         }
 
         foreach ($plugin->registerPDFLayouts() as $layout) {
-            Layout::where('code', $layout)->delete();
+            Layout::where('code', $layout)->get()->each->delete();
         }
 
         Parameter::set('renatio::dynamicpdf.demo', 0);

--- a/models/Layout.php
+++ b/models/Layout.php
@@ -45,6 +45,16 @@ class Layout extends Model
         'background_img' => File::class,
     ];
 
+    public function afterSave(): void
+    {
+        Template::flushLayoutCache();
+    }
+
+    public function afterDelete(): void
+    {
+        Template::flushLayoutCache();
+    }
+
     public function getHtmlAttribute(): string
     {
         return PDF::loadLayout($this->code)->getDompdf()->output_html();

--- a/models/Template.php
+++ b/models/Template.php
@@ -90,17 +90,33 @@ class Template extends Model
         $this->content_html = array_get($sections, 'html');
     }
 
+    /** @var array<string, Layout|null> */
+    protected static array $layoutsByCode = [];
+
+    /**
+     * Every view-driven row of a list re-reads its layout, so the lookup is remembered
+     * per code for the process and forgotten whenever a layout is saved or deleted.
+     */
     protected function resolveLayout(?string $code): ?Layout
     {
         if (! $code) {
             return null;
         }
 
-        try {
-            return Layout::byCode($code);
-        } catch (ModelNotFoundException) {
-            return null;
+        if (array_key_exists($code, self::$layoutsByCode)) {
+            return self::$layoutsByCode[$code];
         }
+
+        try {
+            return self::$layoutsByCode[$code] = Layout::byCode($code);
+        } catch (ModelNotFoundException) {
+            return self::$layoutsByCode[$code] = null;
+        }
+    }
+
+    public static function flushLayoutCache(): void
+    {
+        self::$layoutsByCode = [];
     }
 
     public function getHtmlAttribute(): string

--- a/models/Template.php
+++ b/models/Template.php
@@ -31,6 +31,8 @@ class Template extends Model
 {
     use Validation;
 
+    public const LAYOUT_CACHE = 'renatio.dynamicpdf.layouts';
+
     public $table = 'renatio_dynamicpdf_pdf_templates';
 
     /** @var array<string, string> */
@@ -91,8 +93,6 @@ class Template extends Model
         $this->content_html = array_get($sections, 'html');
     }
 
-    public const LAYOUT_CACHE = 'renatio.dynamicpdf.layouts';
-
     /**
      * Every view-driven row of a list re-reads its layout, so stored layouts are remembered
      * by code for the current request or queue job (a scoped container instance) and each
@@ -110,6 +110,8 @@ class Template extends Model
             try {
                 $layout = Layout::byCode($code);
             } catch (ModelNotFoundException) {
+                $cache[$code] = false;
+
                 return null;
             }
 
@@ -120,14 +122,21 @@ class Template extends Model
             $cache[$code] = $layout->getAttributes();
         }
 
-        return Layout::hydrate([$cache[$code]])->first();
+        return $cache[$code] === false ? null : Layout::hydrate([$cache[$code]])->first();
     }
 
     /**
-     * @return ArrayObject<string, array<string, mixed>>
+     * Registered in Plugin::register(); bound here as well so a save on a disabled plugin
+     * or outside the plugin bootstrap does not fail.
+     *
+     * @return ArrayObject<string, array<string, mixed>|false>
      */
     public static function layoutCache(): ArrayObject
     {
+        if (! app()->bound(self::LAYOUT_CACHE)) {
+            app()->scoped(self::LAYOUT_CACHE, fn (): ArrayObject => new ArrayObject);
+        }
+
         return app(self::LAYOUT_CACHE);
     }
 

--- a/models/Template.php
+++ b/models/Template.php
@@ -2,6 +2,7 @@
 
 namespace Renatio\DynamicPDF\Models;
 
+use ArrayObject;
 use Dompdf\Adapter\CPDF;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Log;
@@ -90,12 +91,12 @@ class Template extends Model
         $this->content_html = array_get($sections, 'html');
     }
 
-    /** @var array<string, Layout|null> */
-    protected static array $layoutsByCode = [];
+    public const LAYOUT_CACHE = 'renatio.dynamicpdf.layouts';
 
     /**
-     * Every view-driven row of a list re-reads its layout, so the lookup is remembered
-     * per code for the process and forgotten whenever a layout is saved or deleted.
+     * Every view-driven row of a list re-reads its layout, so stored layouts are remembered
+     * by code for the current request or queue job (a scoped container instance) and each
+     * template gets its own hydrated copy. Unsaved view fallbacks are not remembered.
      */
     protected function resolveLayout(?string $code): ?Layout
     {
@@ -103,20 +104,36 @@ class Template extends Model
             return null;
         }
 
-        if (array_key_exists($code, self::$layoutsByCode)) {
-            return self::$layoutsByCode[$code];
+        $cache = self::layoutCache();
+
+        if (! isset($cache[$code])) {
+            try {
+                $layout = Layout::byCode($code);
+            } catch (ModelNotFoundException) {
+                return null;
+            }
+
+            if (! $layout->exists) {
+                return $layout;
+            }
+
+            $cache[$code] = $layout->getAttributes();
         }
 
-        try {
-            return self::$layoutsByCode[$code] = Layout::byCode($code);
-        } catch (ModelNotFoundException) {
-            return self::$layoutsByCode[$code] = null;
-        }
+        return Layout::hydrate([$cache[$code]])->first();
+    }
+
+    /**
+     * @return ArrayObject<string, array<string, mixed>>
+     */
+    public static function layoutCache(): ArrayObject
+    {
+        return app(self::LAYOUT_CACHE);
     }
 
     public static function flushLayoutCache(): void
     {
-        self::$layoutsByCode = [];
+        self::layoutCache()->exchangeArray([]);
     }
 
     public function getHtmlAttribute(): string

--- a/tests/OctoberPestTestCase.php
+++ b/tests/OctoberPestTestCase.php
@@ -12,6 +12,7 @@ use October\Tests\Concerns\PerformsMigrations;
 use October\Tests\Concerns\PerformsRegistrations;
 use PDO;
 use ReflectionClass;
+use Renatio\DynamicPDF\Models\Template;
 use TestCase;
 use Throwable;
 
@@ -61,6 +62,7 @@ abstract class OctoberPestTestCase extends TestCase
 
         $this->rollbackDatabaseTransaction();
         $this->flushModelEventListeners();
+        Template::flushLayoutCache();
     }
 
     protected function usingInMemoryDatabase(): bool

--- a/tests/Unit/Models/TemplateListQueriesTest.php
+++ b/tests/Unit/Models/TemplateListQueriesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Template list queries', function () {
+    beforeEach(function () {
+        $this->views = sys_get_temp_dir() . '/dynamicpdf-views-' . uniqid();
+        File::makeDirectory($this->views . '/pdf', 0755, true);
+        View::addNamespace('acmetest', $this->views);
+
+        foreach (['a', 'b', 'c'] as $name) {
+            File::put($this->views . "/pdf/{$name}.htm", "title = \"{$name}\"\nlayout = \"acme::pdf.layouts.default\"\n==\n<p>{$name}</p>");
+        }
+
+        PDFManager::instance()->registerTemplates(['acmetest::pdf.a', 'acmetest::pdf.b', 'acmetest::pdf.c']);
+    });
+
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        File::deleteDirectory($this->views);
+    });
+
+    it('resolves the layout of view-driven templates once per code, not once per row', function () {
+        $this->createLayout(['code' => 'acme::pdf.layouts.default']);
+        foreach (['a', 'b', 'c'] as $name) {
+            $this->createTemplate(['code' => "acmetest::pdf.{$name}", 'is_custom' => false]);
+        }
+
+        DB::enableQueryLog();
+        $templates = Template::query()->get();
+        $layoutQueries = collect(DB::getQueryLog())->filter(fn (array $q): bool => str_contains($q['query'], 'renatio_dynamicpdf_pdf_layouts'))->count();
+        DB::disableQueryLog();
+
+        expect($templates)->toHaveCount(3)
+            ->and($templates->first()?->layout?->code)->toBe('acme::pdf.layouts.default')
+            ->and($layoutQueries)->toBe(1);
+    });
+
+    it('forgets a remembered layout when it is saved', function () {
+        $layout = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'name' => 'Before']);
+        $this->createTemplate(['code' => 'acmetest::pdf.a', 'is_custom' => false]);
+        Template::query()->get();
+
+        $layout->name = 'After';
+        $layout->save();
+
+        expect(Template::byCode('acmetest::pdf.a')->layout?->name)->toBe('After');
+    });
+});

--- a/tests/Unit/Models/TemplateListQueriesTest.php
+++ b/tests/Unit/Models/TemplateListQueriesTest.php
@@ -37,7 +37,19 @@ describe('Template list queries', function () {
 
         expect($templates)->toHaveCount(3)
             ->and($templates->first()?->layout?->code)->toBe('acme::pdf.layouts.default')
+            ->and($templates->first()?->layout === $templates->last()?->layout)->toBeFalse()
             ->and($layoutQueries)->toBe(1);
+    });
+
+    it('does not remember a layout that only exists as a registered view', function () {
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
+        File::put($this->views . '/pdf/a.htm', "title = \"a\"\nlayout = \"renatio.dynamicpdf::pdf.layouts.default\"\n==\n<p>a</p>");
+        $this->createTemplate(['code' => 'acmetest::pdf.a', 'is_custom' => false]);
+
+        $template = Template::byCode('acmetest::pdf.a');
+
+        expect($template->layout?->exists)->toBeFalse()
+            ->and(Template::layoutCache()->count())->toBe(0);
     });
 
     it('forgets a remembered layout when it is saved', function () {

--- a/tests/Unit/Models/TemplateListQueriesTest.php
+++ b/tests/Unit/Models/TemplateListQueriesTest.php
@@ -52,6 +52,31 @@ describe('Template list queries', function () {
             ->and(Template::layoutCache()->count())->toBe(0);
     });
 
+    it('remembers that a layout code is unknown', function () {
+        File::put($this->views . '/pdf/a.htm', "title = \"a\"\nlayout = \"acme::pdf.layouts.unknown\"\n==\n<p>a</p>");
+        foreach (['a', 'b'] as $name) {
+            $this->createTemplate(['code' => "acmetest::pdf.{$name}", 'is_custom' => false]);
+        }
+        File::put($this->views . '/pdf/b.htm', "title = \"b\"\nlayout = \"acme::pdf.layouts.unknown\"\n==\n<p>b</p>");
+
+        DB::enableQueryLog();
+        Template::query()->get();
+        $layoutQueries = collect(DB::getQueryLog())->filter(fn (array $q): bool => str_contains($q['query'], 'renatio_dynamicpdf_pdf_layouts'))->count();
+        DB::disableQueryLog();
+
+        expect($layoutQueries)->toBe(1);
+    });
+
+    it('forgets a remembered layout when it is deleted', function () {
+        $layout = $this->createLayout(['code' => 'acme::pdf.layouts.default']);
+        $this->createTemplate(['code' => 'acmetest::pdf.a', 'is_custom' => false]);
+        Template::query()->get();
+
+        $layout->delete();
+
+        expect(Template::byCode('acmetest::pdf.a')->layout)->toBeNull();
+    });
+
     it('forgets a remembered layout when it is saved', function () {
         $layout = $this->createLayout(['code' => 'acme::pdf.layouts.default', 'name' => 'Before']);
         $this->createTemplate(['code' => 'acmetest::pdf.a', 'is_custom' => false]);

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -64,6 +64,7 @@ v8.0.4:
     - Render templates and layouts with empty content instead of failing.
     - Throw on unknown wrapper methods instead of ignoring them.
     - Render a registered template or layout from its view when it is not stored yet.
+    - Look a layout up once per code instead of once per template row when listing templates.
     - Complete the translations and add French, Italian, Dutch and Russian.
     - Synchronise registered views only in the backend and the demo command, and log a code whose view is missing instead of stopping the whole sync.
     - Add the layout argument to loadTemplate() to render with another layout without changing the template.


### PR DESCRIPTION
## Problem
`Template::afterFetch()` dla `is_custom = false` wywołuje `fillFromView()`, a ten szuka layoutu przez `Layout::byCode()` osobno dla każdego wiersza. Lista szablonów wykonywała N zapytań o layouty.

## Rozwiązanie
Memo `Template::$layoutsByCode` na czas procesu, czyszczone w `Layout::afterSave()` / `afterDelete()` (edycja layoutu w tym samym procesie, np. workerze kolejki, jest widoczna od razu) i w teardownie harnessu testowego. `version.yaml`.

## Testy
`tests/Unit/Models/TemplateListQueriesTest.php` z tymczasowym namespace widoków: 3 szablony z tym samym layoutem → 1 zapytanie o layouty (czerwony przed zmianą: 3); zapis layoutu unieważnia memo (czerwony bez `afterSave`).

Closes #123
