### PR TITLE
Locale per render: zmienna locale zawsze dostępna, pusty string ignorowany, doprecyzowane README

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,12 +518,16 @@ template, so call `setPaper()` when the other layout needs them changed.
 ### Render in another language
 
 The document language usually should not depend on the language of the backend user who generated it. Pass the
-locale to render in; translations, dates and the `locale` template variable follow it, and the application locale is
-restored afterwards, also when rendering fails:
+locale to render in; language file translations (`trans`, `__`), Carbon dates and the `locale` template variable
+follow it while the template is parsed, and the application locale is restored afterwards, also when parsing fails:
 
 ```
 return PDF::loadTemplate('renatio::invoice', $data, locale: 'de')->download('rechnung.pdf');
 ```
+
+The `locale` variable is always available and holds the application locale when no argument is given. RainLab.Translate
+messages (`|_`) and translated model attributes follow the site locale, not this argument, and inline PHP executed by
+dompdf during `output()` runs after the locale has been restored.
 
 ### Change paper size and orientation
 

--- a/README.md
+++ b/README.md
@@ -525,9 +525,10 @@ follow it while the template is parsed, and the application locale is restored a
 return PDF::loadTemplate('renatio::invoice', $data, locale: 'de')->download('rechnung.pdf');
 ```
 
-The `locale` variable is always available and holds the application locale when no argument is given. RainLab.Translate
-messages (`|_`) and translated model attributes follow the site locale, not this argument, and inline PHP executed by
-dompdf during `output()` runs after the locale has been restored.
+`loadTemplate()` and `loadLayout()` always add the `locale` variable, holding the application locale when no argument
+is given; a `locale` key in your own data takes precedence. With RainLab.Translate installed its messages (`|_`) and
+translated model attributes follow the site locale, not this argument, and inline PHP executed by dompdf during
+`output()` runs after the locale has been restored.
 
 ### Change paper size and orientation
 

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -83,8 +83,10 @@ class PDFWrapper extends PDF
             $template->setRelation('layout', Layout::byCode($layout));
         }
 
+        $data = $this->withLocaleVariable($data, $locale);
+
         $this->loadHTML(
-            $this->inLocale($locale, fn (array $data): string => $this->parseTemplate($template, $data), $data),
+            $this->inLocale($locale, fn (): string => $this->parseTemplate($template, $data)),
             $encoding,
         );
 
@@ -102,9 +104,10 @@ class PDFWrapper extends PDF
     public function loadLayout(string $code, array $data = [], ?string $encoding = null, ?string $locale = null): self
     {
         $layout = Layout::byCode($code);
+        $data = $this->withLocaleVariable($data, $locale);
 
         $this->loadHTML(
-            $this->inLocale($locale, fn (array $data): string => $this->parseLayout($layout, $data), $data),
+            $this->inLocale($locale, fn (): string => $this->parseLayout($layout, $data)),
             $encoding,
         );
 
@@ -140,23 +143,31 @@ class PDFWrapper extends PDF
     }
 
     /**
-     * Twig, the translator and Carbon all read the application locale, so it is switched
-     * for the render only and always put back, also when the render throws.
-     *
-     * @param  callable(array<string, mixed>): string  $render
      * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
      */
-    protected function inLocale(?string $locale, callable $render, array $data): string
+    protected function withLocaleVariable(array $data, ?string $locale): array
     {
-        if ($locale === null) {
-            return $render($data);
+        return array_merge(['locale' => $locale ?: app()->getLocale()], $data);
+    }
+
+    /**
+     * The translator and Carbon read the application locale, so it is switched for the
+     * parse only and always put back, also when the parse throws.
+     *
+     * @param  callable(): string  $render
+     */
+    protected function inLocale(?string $locale, callable $render): string
+    {
+        if ($locale === null || $locale === '') {
+            return $render();
         }
 
         $previous = app()->getLocale();
         app()->setLocale($locale);
 
         try {
-            return $render(array_merge(['locale' => $locale], $data));
+            return $render();
         } finally {
             app()->setLocale($previous);
         }

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -148,7 +148,7 @@ class PDFWrapper extends PDF
      */
     protected function withLocaleVariable(array $data, ?string $locale): array
     {
-        return array_merge(['locale' => $locale ?: app()->getLocale()], $data);
+        return array_merge(['locale' => $locale === null || $locale === '' ? app()->getLocale() : $locale], $data);
     }
 
     /**

--- a/tests/Unit/Classes/LocalePerRenderTest.php
+++ b/tests/Unit/Classes/LocalePerRenderTest.php
@@ -3,18 +3,36 @@
 use Twig\Error\SyntaxError;
 
 describe('Locale per render', function () {
+    beforeEach(fn () => app()->setLocale('en'));
+
     it('renders a template in the given locale and restores the previous one', function () {
-        app()->setLocale('en');
-        $this->createTemplate(['code' => 'acme::pdf.invoice', 'content_html' => "{{ 'backend::lang.form.save'|trans }} {{ locale }}"]);
+        $this->createTemplate(['code' => 'acme::pdf.invoice', 'content_html' => "{{ 'renatio.dynamicpdf::lang.templates.label'|trans }} {{ locale }}"]);
 
         $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.invoice', locale: 'pl');
 
-        expect($wrapper->getDomPDF()->outputHtml())->toContain('Zapisz pl')
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('Szablony pl')
             ->and(app()->getLocale())->toBe('en');
     });
 
-    it('restores the previous locale when rendering fails', function () {
-        app()->setLocale('en');
+    it('formats dates in the given locale', function () {
+        $this->createTemplate(['code' => 'acme::pdf.dates', 'content_html' => "{{ date.translatedFormat('F') }}"]);
+
+        $wrapper = app('dynamicpdf')->loadTemplate('acme::pdf.dates', ['date' => \Carbon\Carbon::create(2026, 3, 1)], locale: 'de');
+
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('März');
+    });
+
+    it('exposes the application locale and lets template data override it', function () {
+        $this->createTemplate(['code' => 'acme::pdf.locale', 'content_html' => '{{ locale }}']);
+
+        $default = app('dynamicpdf')->loadTemplate('acme::pdf.locale')->getDomPDF()->outputHtml();
+        $overridden = app('dynamicpdf')->loadTemplate('acme::pdf.locale', ['locale' => 'custom'], locale: 'pl')->getDomPDF()->outputHtml();
+
+        expect($default)->toContain('en')
+            ->and($overridden)->toContain('custom');
+    });
+
+    it('restores the previous locale when parsing fails', function () {
         $this->createTemplate(['code' => 'acme::pdf.broken', 'content_html' => '{{ name']);
 
         expect(fn () => app('dynamicpdf')->loadTemplate('acme::pdf.broken', locale: 'pl'))->toThrow(SyntaxError::class)
@@ -22,12 +40,11 @@ describe('Locale per render', function () {
     });
 
     it('renders a layout in the given locale', function () {
-        app()->setLocale('en');
-        $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => "<html><body>{{ 'backend::lang.form.save'|trans }}</body></html>"]);
+        $this->createLayout(['code' => 'acme::pdf.layouts.default', 'content_html' => "<html><body>{{ 'renatio.dynamicpdf::lang.templates.label'|trans }}</body></html>"]);
 
         $wrapper = app('dynamicpdf')->loadLayout('acme::pdf.layouts.default', locale: 'de');
 
-        expect($wrapper->getDomPDF()->outputHtml())->toContain('Speichern')
+        expect($wrapper->getDomPDF()->outputHtml())->toContain('Vorlagen')
             ->and(app()->getLocale())->toBe('en');
     });
 });


### PR DESCRIPTION
## Kontekst
Follow-up do #151, którego review (Opus) nie zdążył trafić do merge'a (commit nie powstał przez odmowę podpisu z agenta SSH).

## Zmiany
- zmienna `locale` zawsze w danych szablonu (poprzednio tylko z argumentem – pułapka przy `cms.strict_variables`), dane użytkownika mają pierwszeństwo,
- pusty string traktowany jak brak argumentu,
- `inLocale()` bez przekazywania danych przez closure,
- README: podążają tłumaczenia z plików lang i Carbon; komunikaty RainLab.Translate (`|_`) i atrybuty tłumaczone modeli idą za locale site'u; inline PHP w `output()` działa po przywróceniu locale.

## Testy
Carbon (`translatedFormat` → „März”), precedencja danych użytkownika nad `locale`, własne klucze `renatio.dynamicpdf::lang` zamiast `backend::lang`.

Closes #131
