### PR TITLE
Podgląd: chroot dompdfa zawężony do katalogów z zasobami

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ Then in the template you can use following example code:
 
 > The backend preview fetches remote resources only from the hosts listed in `allowed_remote_hosts` of the dompdf
 > configuration or, when that list is empty, from the application host itself, and reads local files only from the
-> web root, plugin and theme assets and public uploads unless `chroot` is set in the configuration.
+> directories October publishes (web root, modules, plugins, themes, app assets, public uploads, media and the resize
+> cache) unless `chroot` is set in the configuration.
 
 When `allow_url_fopen` is disabled on server try to use relative path. You can use October `getLocalPath` function on
 the file object to retrieve it.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Then in the template you can use following example code:
 > For retrieving stylesheets or images via http following PHP setting must be enabled `allow_url_fopen`.
 
 > The backend preview fetches remote resources only from the hosts listed in `allowed_remote_hosts` of the dompdf
-> configuration or, when that list is empty, from the application host itself.
+> configuration or, when that list is empty, from the application host itself, and reads local files only from the
+> web root, plugin and theme assets and public uploads unless `chroot` is set in the configuration.
 
 When `allow_url_fopen` is disabled on server try to use relative path. You can use October `getLocalPath` function on
 the file object to retrieve it.

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -308,6 +308,8 @@ class PDFWrapper extends PDF
      * Remote resources stay limited to the hosts from the dompdf configuration plus the
      * application and site hosts, so a template cannot make the server fetch internal
      * addresses. The request host is deliberately not consulted: it is client-controlled.
+     * Local files stay under the asset directories unless the configuration names its own
+     * chroot, so a template cannot embed .env or the logs through file://.
      */
     public function allowRemoteApplicationAssets(): self
     {
@@ -317,7 +319,28 @@ class PDFWrapper extends PDF
 
         $options->setIsRemoteEnabled(true)->setAllowedRemoteHosts(array_values(array_unique($hosts)));
 
+        if ($options->getChroot() === [realpath(base_path())]) {
+            $options->setChroot(self::previewChroot());
+        }
+
         return $this;
+    }
+
+    /**
+     * The directories a template may legitimately embed files from: the web root, plugin
+     * and theme assets and public uploads. Configuration, logs and protected uploads stay out.
+     *
+     * @return array<int, string>
+     */
+    public static function previewChroot(): array
+    {
+        return [
+            public_path(),
+            plugins_path(),
+            themes_path(),
+            storage_path('app/uploads/public'),
+            storage_path('app/media'),
+        ];
     }
 
     /**

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -319,7 +319,9 @@ class PDFWrapper extends PDF
 
         $options->setIsRemoteEnabled(true)->setAllowedRemoteHosts(array_values(array_unique($hosts)));
 
-        if ($options->getChroot() === [realpath(base_path())]) {
+        $chroot = $options->getChroot();
+
+        if (count($chroot) === 1 && realpath((string) $chroot[0]) === realpath(base_path())) {
             $options->setChroot(self::previewChroot());
         }
 
@@ -327,20 +329,31 @@ class PDFWrapper extends PDF
     }
 
     /**
-     * The directories a template may legitimately embed files from: the web root, plugin
-     * and theme assets and public uploads. Configuration, logs and protected uploads stay out.
+     * The directories a template may legitimately embed files from: what October mirrors as
+     * public plus public uploads and the media and resize caches. Configuration, logs and
+     * protected uploads stay out. Without a public/ folder public_path() is the project root
+     * and is dropped, or the restriction would allow everything again.
      *
      * @return array<int, string>
      */
-    public static function previewChroot(): array
+    protected static function previewChroot(): array
     {
-        return [
+        $base = realpath(base_path());
+
+        $paths = [
             public_path(),
             plugins_path(),
             themes_path(),
+            base_path('modules'),
+            base_path('app'),
             storage_path('app/uploads/public'),
+            storage_path('app/public'),
             storage_path('app/media'),
+            storage_path('app/resources'),
+            storage_path('temp/public'),
         ];
+
+        return array_values(array_filter($paths, fn (string $path): bool => realpath($path) !== $base));
     }
 
     /**

--- a/tests/Feature/PreviewOptionsTest.php
+++ b/tests/Feature/PreviewOptionsTest.php
@@ -80,4 +80,27 @@ describe('Backend preview', function () {
 
         expect(stream_context_get_options($wrapper->getDomPDF()->getHttpContext())['http']['follow_location'])->toBeFalse();
     });
+
+    it('limits local files in the preview to the asset directories', function () {
+        $wrapper = captureWrapper();
+        $template = $this->createTemplate(['content_html' => '<p>Hello</p>']);
+
+        (new Templates)->previewPdf($template->id);
+
+        $options = $wrapper->getDomPDF()->getOptions();
+
+        expect($options->validateLocalUri(base_path('.env'))[0])->toBeFalse()
+            ->and($options->validateLocalUri(storage_path('logs'))[0])->toBeFalse()
+            ->and($options->validateLocalUri(plugins_path('renatio/dynamicpdf/assets/img/october.png')))->toBe([true, null]);
+    });
+
+    it('keeps a custom chroot for the preview', function () {
+        config(['dompdf.options.chroot' => storage_path('app')]);
+        $wrapper = captureWrapper();
+        $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
+
+        (new Layouts)->previewPdf($layout->id);
+
+        expect($wrapper->getDomPDF()->getOptions()->getChroot())->toBe([storage_path('app')]);
+    });
 });

--- a/tests/Feature/PreviewOptionsTest.php
+++ b/tests/Feature/PreviewOptionsTest.php
@@ -89,9 +89,10 @@ describe('Backend preview', function () {
 
         $options = $wrapper->getDomPDF()->getOptions();
 
-        expect($options->validateLocalUri(base_path('.env'))[0])->toBeFalse()
-            ->and($options->validateLocalUri(storage_path('logs'))[0])->toBeFalse()
-            ->and($options->validateLocalUri(plugins_path('renatio/dynamicpdf/assets/img/october.png')))->toBe([true, null]);
+        expect($options->validateLocalUri(base_path('composer.json'))[1])->toContain('Permission denied')
+            ->and($options->validateLocalUri(storage_path('logs'))[1])->toContain('Permission denied')
+            ->and($options->validateLocalUri(plugins_path('renatio/dynamicpdf/assets/img/october.png')))->toBe([true, null])
+            ->and(array_map('realpath', $options->getChroot()))->not->toContain(realpath(base_path()));
     });
 
     it('keeps a custom chroot for the preview', function () {

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -58,7 +58,7 @@ v8.0.3: Refactor to use pluck() function.
 v8.0.4:
     - Security fix. Disable inline PHP in backend preview.
     - Security fix. Sandbox the HTML preview so template scripts cannot run in the backend session.
-    - Security fix. Limit remote resources in the backend preview to the application host.
+    - Security fix. Limit remote resources in the backend preview to the application host and local files to the asset directories.
     - Security fix. Self-signed certificates are accepted only with the allow_self_signed_certificates config, not on every non-production environment.
     - Require PHP 8.2 and October CMS 4.0.
     - Render templates and layouts with empty content instead of failing.


### PR DESCRIPTION
## Problem
Z review #139: `chroot` dompdfa to domyślnie `realpath(base_path())`, a `file://` jest w `allowed_protocols`. Szablon w podglądzie mógł wskazać `.env` albo `storage/logs` jako obraz lub arkusz stylów.

## Rozwiązanie
`allowRemoteApplicationAssets()` (używane w podglądzie) zawęża `chroot` do katalogów z zasobami: `public/`, `plugins/`, `themes/`, `storage/app/uploads/public`, `storage/app/media` — tylko gdy konfiguracja ma domyślny `chroot`; własna wartość zostaje. `public/` w Octoberze zawiera symlinki (`october:mirror`) rozwiązywane przez `realpath`, stąd jawna lista zamiast samego `public_path()`. README (nota przy „Embed image”), `version.yaml`.

## Testy
`PreviewOptionsTest`: `.env` i `storage/logs` odrzucone, asset pluginu dozwolony; skonfigurowany `chroot` zachowany. Pierwszy czerwony przed zmianą.

Closes #143
