### PR TITLE
Komendy dynamicpdf:sync i dynamicpdf:check

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -9,7 +9,9 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Event;
 use RainLab\Translate\Classes\ThemeScanner;
 use Renatio\DynamicPDF\Classes\PDFWrapper;
+use Renatio\DynamicPDF\Console\Check;
 use Renatio\DynamicPDF\Console\Demo;
+use Renatio\DynamicPDF\Console\Sync;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\PluginBase;
@@ -67,6 +69,8 @@ class Plugin extends PluginBase
         $this->app->scoped(Template::LAYOUT_CACHE, fn (): ArrayObject => new ArrayObject);
 
         $this->registerConsoleCommand('dynamicpdf:demo', Demo::class);
+        $this->registerConsoleCommand('dynamicpdf:sync', Sync::class);
+        $this->registerConsoleCommand('dynamicpdf:check', Check::class);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -429,8 +429,9 @@ deleted or failed; it exits with code 1 when a registered code has no view file.
 templates exist before the first backend visit.
 
 `php artisan dynamicpdf:check` reports the dompdf configuration that fails silently: font, cache and temporary
-directories (existence and write access), `chroot`, inline PHP and remote resources, and every registered code
-without a view file. It exits with code 1 on a failure, so it can guard a deployment.
+directories (existence and write access, without creating anything), `chroot`, inline PHP and remote resources, and
+every registered code without a view file. It exits with code 1 on a failure, so it can guard a deployment. Run both
+commands after `october:migrate`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,16 @@ Inline PHP (`setIsPhpEnabled(true)`) is no longer needed for page numbers and sh
 > `<script type="text/php">` block in the HTML is executed on the server, so enabling it for templates that can be
 > edited by backend users allows remote code execution. The backend HTML and PDF preview never enables it.
 
+## Console commands
+
+`php artisan dynamicpdf:sync` synchronises the registered PDF views with the database and lists what was created,
+deleted or failed; it exits with code 1 when a registered code has no view file. Run it after a deployment so the
+templates exist before the first backend visit.
+
+`php artisan dynamicpdf:check` reports the dompdf configuration that fails silently: font, cache and temporary
+directories (existence and write access), `chroot`, inline PHP and remote resources, and every registered code
+without a view file. It exits with code 1 on a failure, so it can guard a deployment.
+
 ## Examples
 
 ### Demo examples

--- a/classes/SyncTemplates.php
+++ b/classes/SyncTemplates.php
@@ -12,8 +12,13 @@ class SyncTemplates
     /** @var array<string, true> */
     protected static array $failed = [];
 
+    /** @var array<string, array<int, string>> */
+    protected array $report = ['created' => [], 'deleted' => [], 'failed' => []];
+
     public function handle(): void
     {
+        $this->report = ['created' => [], 'deleted' => [], 'failed' => []];
+
         $this->createLayouts();
 
         $registeredTemplates = PDFManager::instance()->listRegisteredTemplates();
@@ -26,6 +31,19 @@ class SyncTemplates
 
         $this->clearNonCustomizedTemplates($dbTemplates, $registeredTemplates);
         $this->createTemplates(array_diff_key($registeredTemplates, $dbTemplates));
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function report(): array
+    {
+        return $this->report;
+    }
+
+    public static function forgetFailures(): void
+    {
+        self::$failed = [];
     }
 
     protected function createLayouts(): void
@@ -57,6 +75,7 @@ class SyncTemplates
         foreach ($dbTemplates as $code => $isCustom) {
             if (! $isCustom && ! array_key_exists($code, $registeredTemplates)) {
                 Template::whereCode($code)->delete();
+                $this->report['deleted'][] = $code;
             }
         }
     }
@@ -82,13 +101,17 @@ class SyncTemplates
     protected function create(string $code, callable $create): void
     {
         if (isset(self::$failed[$code])) {
+            $this->report['failed'][] = $code;
+
             return;
         }
 
         try {
             $create();
+            $this->report['created'][] = $code;
         } catch (Throwable $e) {
             self::$failed[$code] = true;
+            $this->report['failed'][] = $code;
 
             Log::error("Renatio.DynamicPDF could not sync {$code}: {$e->getMessage()}", ['exception' => $e]);
         }

--- a/console/Check.php
+++ b/console/Check.php
@@ -36,14 +36,7 @@ class Check extends Command
             config('dompdf.options.enable_php') ? self::WARN . ' enabled: templates can run PHP on the server' : self::PASS . ' disabled',
         );
 
-        $remote = config('dompdf.options.enable_remote');
-        $hosts = config('dompdf.options.allowed_remote_hosts');
-        $this->components->twoColumnDetail(
-            'Remote resources (enable_remote)',
-            $remote
-                ? ($hosts ? self::PASS . ' enabled for ' . implode(', ', $hosts) : self::WARN . ' enabled for any host')
-                : self::PASS . ' disabled',
-        );
+        $this->remote(config('dompdf.options.enable_remote'), config('dompdf.options.allowed_remote_hosts'));
 
         $this->views('Registered layouts', PDFManager::instance()->listRegisteredLayouts() ?? []);
         $this->views('Registered templates', PDFManager::instance()->listRegisteredTemplates() ?? []);
@@ -53,6 +46,32 @@ class Check extends Command
         return $this->failed ? self::FAILURE : self::SUCCESS;
     }
 
+    protected function remote(mixed $enabled, mixed $hosts): void
+    {
+        $label = 'Remote resources (enable_remote)';
+
+        if (! $enabled) {
+            $this->components->twoColumnDetail($label, self::PASS . ' disabled');
+
+            return;
+        }
+
+        if ($hosts !== null && ! is_array($hosts)) {
+            $this->components->twoColumnDetail($label, self::WARN . ' allowed_remote_hosts must be an array; dompdf ignores it and allows any host');
+
+            return;
+        }
+
+        $this->components->twoColumnDetail(
+            $label,
+            $hosts ? self::PASS . ' enabled for ' . implode(', ', $hosts) : self::WARN . ' enabled for any host',
+        );
+    }
+
+    /**
+     * Only reports: creating the directory here would give it the CLI user's ownership and
+     * certify a directory the web server still cannot write to.
+     */
     protected function directory(string $label, mixed $path): void
     {
         if (! is_string($path) || $path === '') {
@@ -61,8 +80,8 @@ class Check extends Command
             return;
         }
 
-        if (! is_dir($path) && ! @mkdir($path, 0755, true)) {
-            $this->report($label, "{$path} does not exist and cannot be created");
+        if (! is_dir($path)) {
+            $this->report($label, "{$path} does not exist; create it and make it writable for the web server");
 
             return;
         }
@@ -97,7 +116,11 @@ class Check extends Command
             return;
         }
 
-        $this->report($label, 'no view file for ' . implode(', ', $missing));
+        $this->report($label, count($missing) . ' without a view file');
+
+        foreach ($missing as $code) {
+            $this->line("  <fg=red>{$code}</>");
+        }
     }
 
     protected function report(string $label, string $message): void

--- a/console/Check.php
+++ b/console/Check.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Renatio\DynamicPDF\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\View;
+use InvalidArgumentException;
+use Renatio\DynamicPDF\Classes\PDFManager;
+
+class Check extends Command
+{
+    protected const PASS = '<fg=green;options=bold>PASS</>';
+
+    protected const WARN = '<fg=yellow;options=bold>WARN</>';
+
+    protected const FAIL = '<fg=red;options=bold>FAIL</>';
+
+    protected $signature = 'dynamicpdf:check';
+
+    protected $description = 'Check the dompdf configuration and the registered PDF views for problems that fail silently.';
+
+    protected bool $failed = false;
+
+    public function handle(): int
+    {
+        $this->newLine();
+
+        $this->directory('Font directory', config('dompdf.options.font_dir'));
+        $this->directory('Font cache', config('dompdf.options.font_cache'));
+        $this->directory('Temporary directory', config('dompdf.options.temp_dir'));
+
+        $this->components->twoColumnDetail('Chroot', implode(', ', (array) config('dompdf.options.chroot')));
+
+        $this->components->twoColumnDetail(
+            'Inline PHP (enable_php)',
+            config('dompdf.options.enable_php') ? self::WARN . ' enabled: templates can run PHP on the server' : self::PASS . ' disabled',
+        );
+
+        $remote = config('dompdf.options.enable_remote');
+        $hosts = config('dompdf.options.allowed_remote_hosts');
+        $this->components->twoColumnDetail(
+            'Remote resources (enable_remote)',
+            $remote
+                ? ($hosts ? self::PASS . ' enabled for ' . implode(', ', $hosts) : self::WARN . ' enabled for any host')
+                : self::PASS . ' disabled',
+        );
+
+        $this->views('Registered layouts', PDFManager::instance()->listRegisteredLayouts() ?? []);
+        $this->views('Registered templates', PDFManager::instance()->listRegisteredTemplates() ?? []);
+
+        $this->newLine();
+
+        return $this->failed ? self::FAILURE : self::SUCCESS;
+    }
+
+    protected function directory(string $label, mixed $path): void
+    {
+        if (! is_string($path) || $path === '') {
+            $this->components->twoColumnDetail($label, self::WARN . ' not configured');
+
+            return;
+        }
+
+        if (! is_dir($path) && ! @mkdir($path, 0755, true)) {
+            $this->report($label, "{$path} does not exist and cannot be created");
+
+            return;
+        }
+
+        if (! is_writable($path)) {
+            $this->report($label, "{$path} is not writable");
+
+            return;
+        }
+
+        $this->components->twoColumnDetail($label, self::PASS . " {$path}");
+    }
+
+    /**
+     * @param  array<string, string>  $codes
+     */
+    protected function views(string $label, array $codes): void
+    {
+        $missing = array_filter($codes, function (string $code): bool {
+            try {
+                View::getFinder()->find($code);
+
+                return false;
+            } catch (InvalidArgumentException) {
+                return true;
+            }
+        });
+
+        if ($missing === []) {
+            $this->components->twoColumnDetail($label, self::PASS . ' ' . count($codes) . ' with a view file');
+
+            return;
+        }
+
+        $this->report($label, 'no view file for ' . implode(', ', $missing));
+    }
+
+    protected function report(string $label, string $message): void
+    {
+        $this->failed = true;
+        $this->components->twoColumnDetail($label, self::FAIL . " {$message}");
+    }
+}

--- a/console/Sync.php
+++ b/console/Sync.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Renatio\DynamicPDF\Console;
+
+use Illuminate\Console\Command;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
+
+class Sync extends Command
+{
+    protected $signature = 'dynamicpdf:sync';
+
+    protected $description = 'Synchronise the registered PDF views with the database and report the outcome.';
+
+    public function handle(): int
+    {
+        SyncTemplates::forgetFailures();
+
+        $sync = new SyncTemplates;
+        $sync->handle();
+        $report = $sync->report();
+
+        $this->list('Created', $report['created'], 'green');
+        $this->list('Deleted', $report['deleted'], 'yellow');
+        $this->list('Failed (see the application log)', $report['failed'], 'red');
+
+        if ($report === ['created' => [], 'deleted' => [], 'failed' => []]) {
+            $this->components->info('Everything is up to date.');
+        }
+
+        return $report['failed'] === [] ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<int, string>  $codes
+     */
+    protected function list(string $label, array $codes, string $color): void
+    {
+        if ($codes === []) {
+            return;
+        }
+
+        $this->line("<fg={$color};options=bold>{$label}</>");
+
+        foreach ($codes as $code) {
+            $this->line("  {$code}");
+        }
+    }
+}

--- a/console/Sync.php
+++ b/console/Sync.php
@@ -23,7 +23,7 @@ class Sync extends Command
         $this->list('Deleted', $report['deleted'], 'yellow');
         $this->list('Failed (see the application log)', $report['failed'], 'red');
 
-        if ($report === ['created' => [], 'deleted' => [], 'failed' => []]) {
+        if (array_filter($report) === []) {
             $this->components->info('Everything is up to date.');
         }
 

--- a/tests/Unit/Classes/SyncTemplatesTest.php
+++ b/tests/Unit/Classes/SyncTemplatesTest.php
@@ -11,6 +11,7 @@ use Renatio\DynamicPDF\Plugin;
 describe('SyncTemplates', function () {
     beforeEach(function () {
         PDFManager::forgetInstance();
+        SyncTemplates::forgetFailures();
         PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
         PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
     });

--- a/tests/Unit/Classes/SyncTemplatesTest.php
+++ b/tests/Unit/Classes/SyncTemplatesTest.php
@@ -17,7 +17,7 @@ describe('SyncTemplates', function () {
 
     afterEach(function () {
         PDFManager::forgetInstance();
-        (new ReflectionProperty(SyncTemplates::class, 'failed'))->setValue(null, []);
+        SyncTemplates::forgetFailures();
     });
 
     it('creates registered layouts and templates from their views', function () {

--- a/tests/Unit/Console/CheckCommandTest.php
+++ b/tests/Unit/Console/CheckCommandTest.php
@@ -4,6 +4,8 @@ use Illuminate\Support\Facades\Artisan;
 use Renatio\DynamicPDF\Classes\PDFManager;
 
 describe('dynamicpdf:check', function () {
+    beforeEach(fn () => PDFManager::forgetInstance());
+
     afterEach(fn () => PDFManager::forgetInstance());
 
     it('passes with the default configuration', function () {
@@ -11,11 +13,21 @@ describe('dynamicpdf:check', function () {
             ->and(Artisan::output())->toContain('PASS');
     });
 
-    it('fails when the font directory cannot be created', function () {
-        config(['dompdf.options.font_dir' => __FILE__ . '/fonts']);
+    it('fails when the font directory is missing without creating it', function () {
+        $missing = sys_get_temp_dir() . '/dynamicpdf-missing-' . uniqid();
+        config(['dompdf.options.font_dir' => $missing]);
 
         expect(Artisan::call('dynamicpdf:check'))->toBe(1)
-            ->and(Artisan::output())->toContain('FAIL');
+            ->and(Artisan::output())->toContain('FAIL')
+            ->and($missing)->not->toBeDirectory();
+    });
+
+    it('warns when allowed_remote_hosts is not an array', function () {
+        config(['dompdf.options.enable_remote' => true, 'dompdf.options.allowed_remote_hosts' => 'cdn.example.com']);
+
+        Artisan::call('dynamicpdf:check');
+
+        expect(Artisan::output())->toContain('must be an array');
     });
 
     it('warns when inline PHP is enabled', function () {

--- a/tests/Unit/Console/CheckCommandTest.php
+++ b/tests/Unit/Console/CheckCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Renatio\DynamicPDF\Classes\PDFManager;
+
+describe('dynamicpdf:check', function () {
+    afterEach(fn () => PDFManager::forgetInstance());
+
+    it('passes with the default configuration', function () {
+        expect(Artisan::call('dynamicpdf:check'))->toBe(0)
+            ->and(Artisan::output())->toContain('PASS');
+    });
+
+    it('fails when the font directory cannot be created', function () {
+        config(['dompdf.options.font_dir' => __FILE__ . '/fonts']);
+
+        expect(Artisan::call('dynamicpdf:check'))->toBe(1)
+            ->and(Artisan::output())->toContain('FAIL');
+    });
+
+    it('warns when inline PHP is enabled', function () {
+        config(['dompdf.options.enable_php' => true]);
+
+        Artisan::call('dynamicpdf:check');
+
+        expect(Artisan::output())->toContain('WARN');
+    });
+
+    it('fails for a registered code without a view file', function () {
+        PDFManager::forgetInstance();
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.nowhere']);
+
+        expect(Artisan::call('dynamicpdf:check'))->toBe(1)
+            ->and(Artisan::output())->toContain('renatio.dynamicpdf::pdf.nowhere');
+    });
+});

--- a/tests/Unit/Console/SyncCommandTest.php
+++ b/tests/Unit/Console/SyncCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('dynamicpdf:sync', function () {
+    afterEach(fn () => PDFManager::forgetInstance());
+
+    it('creates registered views and reports what it did', function () {
+        PDFManager::forgetInstance();
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default', 'renatio.dynamicpdf::pdf.layouts.missing']);
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+
+        $exitCode = Artisan::call('dynamicpdf:sync');
+        $output = Artisan::output();
+
+        expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue()
+            ->and($output)->toContain('renatio.dynamicpdf::pdf.layouts.default')
+            ->and($output)->toContain('renatio.dynamicpdf::pdf.invoice')
+            ->and($output)->toContain('renatio.dynamicpdf::pdf.layouts.missing')
+            ->and($exitCode)->toBe(1);
+    });
+});

--- a/tests/Unit/Console/SyncCommandTest.php
+++ b/tests/Unit/Console/SyncCommandTest.php
@@ -2,10 +2,14 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Models\Template;
 
 describe('dynamicpdf:sync', function () {
-    afterEach(fn () => PDFManager::forgetInstance());
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        SyncTemplates::forgetFailures();
+    });
 
     it('creates registered views and reports what it did', function () {
         PDFManager::forgetInstance();

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -70,4 +70,5 @@ v8.0.4:
     - Add the layout argument to loadTemplate() to render with another layout without changing the template.
     - Add the locale argument to loadTemplate() and loadLayout() to render in another language and restore the previous one.
     - Add pageNumbers() to stamp page numbers without inline PHP.
+    - Add the dynamicpdf:sync and dynamicpdf:check console commands.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Zakres
- `dynamicpdf:sync` — jawna synchronizacja z raportem (utworzone / usunięte / nieudane), kod wyjścia 1 gdy jakiś zarejestrowany kod nie ma pliku widoku; do skryptu deployu. `SyncTemplates` zbiera raport (`report()`) i ma `forgetFailures()` (używane też w testach zamiast refleksji).
- `dynamicpdf:check` — diagnostyka w stylu `seo:doctor`: katalogi fontów, cache i temp (istnienie, zapis), `chroot`, inline PHP (WARN gdy włączone), zdalne zasoby (WARN gdy dowolny host), zarejestrowane kody bez pliku widoku (FAIL). Kod wyjścia 1 przy FAIL.
- README: sekcja *Console commands*; `version.yaml`.

Domyka punkt 1 z mplodowski/cico-www#170 (widoczność braku katalogu fontów).

## Testy
`tests/Unit/Console/SyncCommandTest.php`, `CheckCommandTest.php`: raport syncu z brakującym widokiem i kodem 1; check PASS domyślnie, FAIL dla niemożliwego katalogu fontów i brakującego widoku, WARN dla `enable_php`. Asercje na `Artisan::output()` zgodnie z `.ai/rules/test-scope.md`.

Closes #133
