### PR TITLE
toFile() do System\Models\File i łańcuchowalne encrypt()

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,10 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 | setPaper($paper, $orientation = 'portrait')             | Set the paper size and orientation (default A4/portrait) |
 | setWarnings($warnings)                                  | Show or hide warnings                                    |
 | output()                                                | Output the PDF as a string                               |
-| save($filename)                                         | Save the PDF to a file                                   |
+| toFile($filename = 'document.pdf')                      | Return the PDF as a System\Models\File to attach to a model |
+| encrypt($password, $ownerPassword = '', $permissions = []) | Password-protect the PDF (CPDF backend)               |
+| addInfo(array $info)                                    | Set PDF metadata such as Title or Author                 |
+| save($filename, $disk = null)                           | Save the PDF to a file, optionally on a storage disk     |
 | download($filename = 'document.pdf')                    | Make the PDF downloadable by the user                    |
 | stream($filename = 'document.pdf')                      | Return a response with the PDF to show in the browser    |
 
@@ -394,6 +397,30 @@ Then in the template you can use following example code:
 
 When `allow_url_fopen` is disabled on server try to use relative path. You can use October `getLocalPath` function on
 the file object to retrieve it.
+
+### Attach the PDF to a model
+
+`toFile()` returns a `System\Models\File` built from the rendered document, so the PDF can be attached with October's
+`attachOne` / `attachMany` relations instead of being written to disk by hand:
+
+```
+$order->invoice = PDF::loadTemplate('renatio::invoice', ['order' => $order])->toFile('invoice.pdf');
+$order->save();
+```
+
+### Save to a storage disk and set metadata
+
+```
+PDF::loadTemplate('renatio::invoice')
+    ->addInfo(['Title' => 'Invoice 2026/1', 'Author' => 'Acme'])
+    ->save('invoices/2026-1.pdf', 's3');
+```
+
+### Password protection
+
+```
+return PDF::loadTemplate('renatio::invoice')->encrypt('reader-password', 'owner-password', ['print'])->stream();
+```
 
 ### Download PDF via Ajax response
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 | setPaper($paper, $orientation = 'portrait')             | Set the paper size and orientation (default A4/portrait) |
 | setWarnings($warnings)                                  | Show or hide warnings                                    |
 | output()                                                | Output the PDF as a string                               |
-| toFile($filename = 'document.pdf')                      | Return the PDF as a System\Models\File to attach to a model |
+| toFile($filename = 'document.pdf', $public = true)      | Return the PDF as a System\Models\File to attach to a model |
 | encrypt($password, $ownerPassword = '', $permissions = []) | Password-protect the PDF (CPDF backend)               |
 | addInfo(array $info)                                    | Set PDF metadata such as Title or Author                 |
 | save($filename, $disk = null)                           | Save the PDF to a file, optionally on a storage disk     |
@@ -404,9 +404,13 @@ the file object to retrieve it.
 `attachOne` / `attachMany` relations instead of being written to disk by hand:
 
 ```
-$order->invoice = PDF::loadTemplate('renatio::invoice', ['order' => $order])->toFile('invoice.pdf');
+$order->invoice = PDF::loadTemplate('renatio::invoice', ['order' => $order])->toFile('invoice.pdf', public: false);
 $order->save();
 ```
+
+Pass `public: false` for a relation declared with `'public' => false`, otherwise the record points at the wrong
+directory. The file is written to the uploads disk as soon as `toFile()` returns, so attach and save it, or call
+`$file->delete()` when you abandon it.
 
 ### Save to a storage disk and set metadata
 
@@ -421,6 +425,9 @@ PDF::loadTemplate('renatio::invoice')
 ```
 return PDF::loadTemplate('renatio::invoice')->encrypt('reader-password', 'owner-password', ['print'])->stream();
 ```
+
+`encrypt()` renders the document, so call it last, right before the output method. Permissions are opt-in: without
+`['print', 'copy', ...]` the reader cannot print or copy. Requires the CPDF backend.
 
 ### Download PDF via Ajax response
 

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -12,7 +12,7 @@ use Renatio\DynamicPDF\Models\Template;
  * @method static string parseTemplate(Template $template, array<string, mixed> $data = [])
  * @method static string parseLayout(Layout $layout, array<string, mixed> $data = [])
  * @method static PDFWrapper pageNumbers(string $text = 'Page {PAGE_NUM} of {PAGE_COUNT}', string $position = 'bottom-center', float $size = 9, ?string $font = null, float $margin = 20, array<int, float> $color = [0, 0, 0])
- * @method static \System\Models\File toFile(string $filename = 'document.pdf')
+ * @method static \System\Models\File toFile(string $filename = 'document.pdf', bool $public = true)
  * @method static PDFWrapper encrypt(string $password, string $ownerPassword = '', array<int, string> $permissions = [])
  * @method static PDFWrapper allowRemoteApplicationAssets()
  * @method static PDFWrapper allowSelfSignedCertificates()

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -12,6 +12,8 @@ use Renatio\DynamicPDF\Models\Template;
  * @method static string parseTemplate(Template $template, array<string, mixed> $data = [])
  * @method static string parseLayout(Layout $layout, array<string, mixed> $data = [])
  * @method static PDFWrapper pageNumbers(string $text = 'Page {PAGE_NUM} of {PAGE_COUNT}', string $position = 'bottom-center', float $size = 9, ?string $font = null, float $margin = 20, array<int, float> $color = [0, 0, 0])
+ * @method static \System\Models\File toFile(string $filename = 'document.pdf')
+ * @method static PDFWrapper encrypt(string $password, string $ownerPassword = '', array<int, string> $permissions = [])
  * @method static PDFWrapper allowRemoteApplicationAssets()
  * @method static PDFWrapper allowSelfSignedCertificates()
  */

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -136,18 +136,25 @@ class PDFWrapper extends PDF
     }
 
     /**
-     * The rendered document as a file record ready to be attached to a model.
+     * The rendered document as a file record ready to be attached to a model. The bytes are
+     * written to the uploads disk right away, so attach and save the record or delete it.
+     * $public must match the relation's public flag, or the row points at the wrong directory.
      */
-    public function toFile(string $filename = 'document.pdf'): File
+    public function toFile(string $filename = 'document.pdf', bool $public = true): File
     {
         $file = new File;
+        $file->setAttribute('is_public', $public);
         $file->fromData($this->output(), $filename);
 
         return $file;
     }
 
     /**
-     * @param  array<int, string>  $permissions  dompdf permission names, for example ['print']
+     * Renders the document, so call it last, right before output(), stream(), download(),
+     * save() or toFile(); a later loadHTML() or setPaper() rebuilds the canvas unencrypted.
+     * Permissions are opt-in: print, modify, copy, add.
+     *
+     * @param  array<int, string>  $permissions
      */
     public function encrypt(string $password, string $ownerPassword = '', array $permissions = []): self
     {

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -16,6 +16,7 @@ use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 use System\Classes\SiteManager;
 use System\Facades\System;
+use System\Models\File;
 use System\Models\SiteDefinition;
 use Twig\Environment;
 use UnexpectedValueException;
@@ -132,6 +133,27 @@ class PDFWrapper extends PDF
         $y = $vertical === 'top' ? $numbers['margin'] : $canvas->get_height() - $numbers['margin'] - $height;
 
         $canvas->page_text($x, $y, $numbers['text'], $font, $numbers['size'], $numbers['color']);
+    }
+
+    /**
+     * The rendered document as a file record ready to be attached to a model.
+     */
+    public function toFile(string $filename = 'document.pdf'): File
+    {
+        $file = new File;
+        $file->fromData($this->output(), $filename);
+
+        return $file;
+    }
+
+    /**
+     * @param  array<int, string>  $permissions  dompdf permission names, for example ['print']
+     */
+    public function encrypt(string $password, string $ownerPassword = '', array $permissions = []): self
+    {
+        $this->setEncryption($password, $ownerPassword, $permissions);
+
+        return $this;
     }
 
     public function __call($method, $parameters)

--- a/tests/Unit/Classes/OutputHelpersTest.php
+++ b/tests/Unit/Classes/OutputHelpersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+describe('Output helpers', function () {
+    beforeEach(function () {
+        $this->uploads = sys_get_temp_dir() . '/dynamicpdf-uploads-' . uniqid();
+        config(['filesystems.disks.uploads.root' => $this->uploads]);
+        Storage::forgetDisk('uploads');
+    });
+
+    afterEach(function () {
+        Storage::forgetDisk('uploads');
+        File::deleteDirectory($this->uploads);
+    });
+
+    it('turns the document into an attachable file record', function () {
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>Hello</p>');
+
+        $file = $wrapper->toFile('hello.pdf');
+        $stored = File::allFiles($this->uploads);
+
+        expect((string) $file->getAttribute('file_name'))->toBe('hello.pdf')
+            ->and((string) $file->getAttribute('content_type'))->toBe('application/pdf')
+            ->and((int) $file->getAttribute('file_size'))->toBeGreaterThan(0)
+            ->and($stored)->toHaveCount(1)
+            ->and(file_get_contents($stored[0]->getPathname()))->toStartWith('%PDF');
+    });
+
+    it('encrypts the document and stays chainable', function () {
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>Secret</p>');
+
+        $output = $wrapper->encrypt('reader', 'owner')->output();
+
+        expect($output)->toContain('/Encrypt');
+    });
+});

--- a/tests/Unit/Classes/OutputHelpersTest.php
+++ b/tests/Unit/Classes/OutputHelpersTest.php
@@ -29,6 +29,16 @@ describe('Output helpers', function () {
             ->and(file_get_contents($stored[0]->getPathname()))->toStartWith('%PDF');
     });
 
+    it('stores a protected file where a protected relation expects it', function () {
+        $wrapper = app('dynamicpdf');
+        $wrapper->loadHTML('<p>Hello</p>');
+
+        $file = $wrapper->toFile('hello.pdf', public: false);
+
+        expect($file->getAttribute('is_public'))->toBeFalsy()
+            ->and(File::allFiles($this->uploads . '/protected'))->toHaveCount(1);
+    });
+
     it('encrypts the document and stays chainable', function () {
         $wrapper = app('dynamicpdf');
         $wrapper->loadHTML('<p>Secret</p>');

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -71,4 +71,5 @@ v8.0.4:
     - Add the locale argument to loadTemplate() and loadLayout() to render in another language and restore the previous one.
     - Add pageNumbers() to stamp page numbers without inline PHP.
     - Add the dynamicpdf:sync and dynamicpdf:check console commands.
+    - Add toFile() and a chainable encrypt().
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Zakres
- `toFile(string $filename = 'document.pdf'): System\Models\File` — rekord pliku z wyrenderowanego PDF-a gotowy do `attachOne`/`attachMany` (zamiast ręcznego `file_put_contents` do `storage/app`, por. mplodowski/cico-www#17, #101),
- `encrypt($password, $ownerPassword = '', $permissions = []): self` — łańcuchowalny wrapper na `setEncryption()`, które zwraca `void`,
- README: tabela metod (`save($filename, $disk)`, `addInfo()`, `toFile()`, `encrypt()`), przykłady *Attach the PDF to a model*, *Save to a storage disk and set metadata*, *Password protection*; `@method` na fasadzie; `version.yaml`.

## Testy
`tests/Unit/Classes/OutputHelpersTest.php`: `toFile()` tworzy rekord z poprawnym `content_type`, rozmiarem i plikiem `%PDF` na dysku `uploads` przekierowanym do katalogu tymczasowego (bez zapisu do `storage/app/uploads` projektu); `encrypt()` zwraca wrapper, a wynik ma `/Encrypt`.

Closes #137
