### PR TITLE
registerPDFVariables() i zdarzenia beforeRender / afterRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,38 @@ active, so theme partials and content blocks are available. Otherwise, for examp
 that loads only the System and Backend modules, the system Twig environment is used. Filters and functions registered
 by plugins through `registerMarkupTags` work in both.
 
+## Global variables
+
+Variables every template and layout should receive, such as company details or a logo URL, are registered in the
+plugin registration class. A closure value is resolved when the document is rendered:
+
+```
+public function registerPDFVariables()
+{
+    return [
+        'company' => 'Acme Ltd',
+        'vat_rate' => fn () => Settings::get('vat_rate'),
+    ];
+}
+```
+
+Data passed to `loadTemplate()`, `loadLayout()` or `parseTemplate()` takes precedence over a registered variable.
+
+## Events
+
+| Event                              | Payload                                       | Return value                              |
+|------------------------------------|-----------------------------------------------|-------------------------------------------|
+| `renatio.dynamicpdf.beforeRender`  | `PDFWrapper $pdf`, `Template\|Layout $model`, `array $data` | an array merged on top of the render data |
+| `renatio.dynamicpdf.afterRender`   | `PDFWrapper $pdf`, `Template\|Layout $model`, `string $html` | a string replacing the rendered HTML      |
+
+```
+Event::listen('renatio.dynamicpdf.beforeRender', function ($pdf, $model, array $data) {
+    return ['watermark' => $data['order']->isDraft() ? 'DRAFT' : null];
+});
+```
+
+Both events fire once per document: for a template together with its layout, or for a layout loaded on its own.
+
 ## Usage
 
 PDF templates and layouts can be accessed in the back-end area via *Settings > PDF > PDF Templates*.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ public function registerPDFVariables()
 }
 ```
 
-Data passed to `loadTemplate()`, `loadLayout()` or `parseTemplate()` takes precedence over a registered variable.
+Data passed to `loadTemplate()`, `loadLayout()` or `parseTemplate()` takes precedence over a registered variable. The
+names `content_html`, `css`, `background_img` and `locale` are reserved for the wrapper and ignored when registered.
+Every closure is resolved on every render, whether or not the template uses it, so keep them cheap.
 
 ## Events
 
@@ -258,7 +260,10 @@ Event::listen('renatio.dynamicpdf.beforeRender', function ($pdf, $model, array $
 });
 ```
 
-Both events fire once per document: for a template together with its layout, or for a layout loaded on its own.
+Both events fire once per document: for a template together with its layout (`loadTemplate()`, `parseTemplate()`),
+or for a layout rendered on its own (`loadLayout()`, `parseLayout()`). They also fire for the backend HTML and PDF
+preview, so keep side effects such as counters or audit entries out of the listeners or check `$pdf` for the preview
+context yourself. A listener that returns `false` stops the remaining listeners, as with every October event.
 
 ## Usage
 

--- a/classes/Events.php
+++ b/classes/Events.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Renatio\DynamicPDF\Classes;
+
+/**
+ * The payload of each event is documented in the README.
+ */
+class Events
+{
+    public const BEFORE_RENDER = 'renatio.dynamicpdf.beforeRender';
+
+    public const AFTER_RENDER = 'renatio.dynamicpdf.afterRender';
+}

--- a/classes/PDFManager.php
+++ b/classes/PDFManager.php
@@ -16,6 +16,9 @@ class PDFManager
     /** @var array<string, string>|null */
     protected ?array $registeredLayouts = null;
 
+    /** @var array<string, mixed>|null */
+    protected ?array $registeredVariables = null;
+
     public function loadRegisteredTemplates(): void
     {
         $plugins = PluginManager::instance()->getPlugins();
@@ -40,7 +43,37 @@ class PDFManager
                     $this->registerTemplates($templates);
                 }
             }
+
+            if (method_exists($plugin, 'registerPDFVariables')) {
+                $variables = $plugin->registerPDFVariables();
+
+                if (is_array($variables)) {
+                    $this->registerVariables($variables);
+                }
+            }
         }
+    }
+
+    /**
+     * Variables every template and layout receives. A closure value is resolved at render time.
+     *
+     * @return array<string, mixed>
+     */
+    public function listRegisteredVariables(): array
+    {
+        if ($this->registeredVariables === null) {
+            $this->loadRegisteredTemplates();
+        }
+
+        return $this->registeredVariables ?? [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    public function registerVariables(array $variables): void
+    {
+        $this->registeredVariables = array_merge($this->registeredVariables ?? [], $variables);
     }
 
     /**

--- a/classes/PDFManager.php
+++ b/classes/PDFManager.php
@@ -10,48 +10,66 @@ class PDFManager
 {
     use Singleton;
 
-    /** @var array<string, string>|null */
-    protected ?array $registeredTemplates = null;
+    /** @var array<string, string> */
+    protected array $registeredTemplates = [];
 
-    /** @var array<string, string>|null */
-    protected ?array $registeredLayouts = null;
+    /** @var array<string, string> */
+    protected array $registeredLayouts = [];
 
-    /** @var array<string, mixed>|null */
-    protected ?array $registeredVariables = null;
+    /** @var array<string, mixed> */
+    protected array $registeredVariables = [];
 
+    protected bool $loaded = false;
+
+    /**
+     * Collects the registrations of every plugin once; direct register*() calls made before
+     * that are kept alongside them.
+     */
     public function loadRegisteredTemplates(): void
     {
-        $plugins = PluginManager::instance()->getPlugins();
+        if ($this->loaded) {
+            return;
+        }
 
-        foreach ($plugins as $plugin) {
+        $this->loaded = true;
+
+        foreach (PluginManager::instance()->getPlugins() as $plugin) {
             if (! $plugin instanceof PluginBase) {
                 continue;
             }
 
-            if (method_exists($plugin, 'registerPDFLayouts')) {
-                $layouts = $plugin->registerPDFLayouts();
-
-                if (is_array($layouts)) {
-                    $this->registerLayouts($layouts);
-                }
+            if (method_exists($plugin, 'registerPDFLayouts') && is_array($layouts = $plugin->registerPDFLayouts())) {
+                $this->registerLayouts($layouts);
             }
 
-            if (method_exists($plugin, 'registerPDFTemplates')) {
-                $templates = $plugin->registerPDFTemplates();
-
-                if (is_array($templates)) {
-                    $this->registerTemplates($templates);
-                }
+            if (method_exists($plugin, 'registerPDFTemplates') && is_array($templates = $plugin->registerPDFTemplates())) {
+                $this->registerTemplates($templates);
             }
 
-            if (method_exists($plugin, 'registerPDFVariables')) {
-                $variables = $plugin->registerPDFVariables();
-
-                if (is_array($variables)) {
-                    $this->registerVariables($variables);
-                }
+            if (method_exists($plugin, 'registerPDFVariables') && is_array($variables = $plugin->registerPDFVariables())) {
+                $this->registerVariables($variables);
             }
         }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function listRegisteredLayouts(): array
+    {
+        $this->loadRegisteredTemplates();
+
+        return $this->registeredLayouts;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function listRegisteredTemplates(): array
+    {
+        $this->loadRegisteredTemplates();
+
+        return $this->registeredTemplates;
     }
 
     /**
@@ -61,43 +79,9 @@ class PDFManager
      */
     public function listRegisteredVariables(): array
     {
-        if ($this->registeredVariables === null) {
-            $this->loadRegisteredTemplates();
-        }
+        $this->loadRegisteredTemplates();
 
-        return $this->registeredVariables ?? [];
-    }
-
-    /**
-     * @param  array<string, mixed>  $variables
-     */
-    public function registerVariables(array $variables): void
-    {
-        $this->registeredVariables = array_merge($this->registeredVariables ?? [], $variables);
-    }
-
-    /**
-     * @return array<string, string>|null
-     */
-    public function listRegisteredLayouts(): ?array
-    {
-        if ($this->registeredLayouts === null) {
-            $this->loadRegisteredTemplates();
-        }
-
-        return $this->registeredLayouts;
-    }
-
-    /**
-     * @return array<string, string>|null
-     */
-    public function listRegisteredTemplates(): ?array
-    {
-        if ($this->registeredTemplates === null) {
-            $this->loadRegisteredTemplates();
-        }
-
-        return $this->registeredTemplates;
+        return $this->registeredVariables;
     }
 
     /**
@@ -105,11 +89,7 @@ class PDFManager
      */
     public function registerLayouts(array $definitions): void
     {
-        $this->registeredLayouts ??= [];
-
-        $definitions = array_combine($definitions, $definitions);
-
-        $this->registeredLayouts = $definitions + $this->registeredLayouts;
+        $this->registeredLayouts = array_combine($definitions, $definitions) + $this->registeredLayouts;
     }
 
     /**
@@ -117,10 +97,14 @@ class PDFManager
      */
     public function registerTemplates(array $definitions): void
     {
-        $this->registeredTemplates ??= [];
+        $this->registeredTemplates = array_combine($definitions, $definitions) + $this->registeredTemplates;
+    }
 
-        $definitions = array_combine($definitions, $definitions);
-
-        $this->registeredTemplates = $definitions + $this->registeredTemplates;
+    /**
+     * @param  array<string, mixed>  $variables
+     */
+    public function registerVariables(array $variables): void
+    {
+        $this->registeredVariables = array_merge($this->registeredVariables, $variables);
     }
 }

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -3,6 +3,7 @@
 namespace Renatio\DynamicPDF\Classes;
 
 use Barryvdh\DomPDF\PDF;
+use Closure;
 use Cms\Classes\Controller;
 use Cms\Classes\Theme;
 use Dompdf\Dompdf;
@@ -10,6 +11,7 @@ use Exception;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Renatio\DynamicPDF\Models\Layout;
@@ -223,7 +225,7 @@ class PDFWrapper extends PDF
         $data = $this->withLocaleVariable($data, $locale);
 
         $this->loadHTML(
-            $this->inLocale($locale, fn (): string => $this->parseLayout($layout, $data)),
+            $this->inLocale($locale, fn (): string => $this->renderWithEvents($layout, $data, fn (array $data): string => $this->parseLayout($layout, $data))),
             $encoding,
         );
 
@@ -235,15 +237,56 @@ class PDFWrapper extends PDF
      */
     public function parseTemplate(Template $template, array $data = []): string
     {
-        $html = $this->parseMarkup($template->content_html, $data);
+        return $this->renderWithEvents($template, $data, function (array $data) use ($template): string {
+            $html = $this->parseMarkup($template->content_html, $data);
 
-        if (! $template->layout) {
-            return $html;
+            if (! $template->layout) {
+                return $html;
+            }
+
+            return $this->parseLayout(
+                $template->layout,
+                array_merge(['content_html' => $html], $data),
+            );
+        });
+    }
+
+    /**
+     * Registered variables sit under the render data, a beforeRender listener may return
+     * data to merge on top, and an afterRender listener may return the HTML to use instead.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  callable(array<string, mixed>): string  $render
+     */
+    protected function renderWithEvents(Template|Layout $model, array $data, callable $render): string
+    {
+        $data = array_merge($this->registeredVariables(), $data);
+
+        foreach (Event::fire(Events::BEFORE_RENDER, [$this, $model, $data]) ?? [] as $extra) {
+            if (is_array($extra)) {
+                $data = array_merge($data, $extra);
+            }
         }
 
-        return $this->parseLayout(
-            $template->layout,
-            array_merge(['content_html' => $html], $data),
+        $html = $render($data);
+
+        foreach (Event::fire(Events::AFTER_RENDER, [$this, $model, $html]) ?? [] as $replacement) {
+            if (is_string($replacement)) {
+                $html = $replacement;
+            }
+        }
+
+        return $html;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function registeredVariables(): array
+    {
+        return array_map(
+            fn (mixed $value): mixed => $value instanceof Closure ? $value() : $value,
+            PDFManager::instance()->listRegisteredVariables(),
         );
     }
 

--- a/classes/PDFWrapper.php
+++ b/classes/PDFWrapper.php
@@ -225,7 +225,7 @@ class PDFWrapper extends PDF
         $data = $this->withLocaleVariable($data, $locale);
 
         $this->loadHTML(
-            $this->inLocale($locale, fn (): string => $this->renderWithEvents($layout, $data, fn (array $data): string => $this->parseLayout($layout, $data))),
+            $this->inLocale($locale, fn (): string => $this->parseLayout($layout, $data)),
             $encoding,
         );
 
@@ -244,7 +244,7 @@ class PDFWrapper extends PDF
                 return $html;
             }
 
-            return $this->parseLayout(
+            return $this->renderLayout(
                 $template->layout,
                 array_merge(['content_html' => $html], $data),
             );
@@ -252,19 +252,26 @@ class PDFWrapper extends PDF
     }
 
     /**
+     * Keys the wrapper sets itself; a registered variable or listener cannot take them over.
+     */
+    public const RESERVED_VARIABLES = ['content_html', 'css', 'background_img', 'locale'];
+
+    /**
      * Registered variables sit under the render data, a beforeRender listener may return
      * data to merge on top, and an afterRender listener may return the HTML to use instead.
+     * Fires once per document: parseTemplate() renders the layout without going through
+     * parseLayout(), which fires for a layout rendered on its own.
      *
      * @param  array<string, mixed>  $data
      * @param  callable(array<string, mixed>): string  $render
      */
     protected function renderWithEvents(Template|Layout $model, array $data, callable $render): string
     {
-        $data = array_merge($this->registeredVariables(), $data);
+        $data = array_merge($this->withoutReserved($this->registeredVariables()), $data);
 
         foreach (Event::fire(Events::BEFORE_RENDER, [$this, $model, $data]) ?? [] as $extra) {
             if (is_array($extra)) {
-                $data = array_merge($data, $extra);
+                $data = array_merge($data, $this->withoutReserved($extra));
             }
         }
 
@@ -277,6 +284,15 @@ class PDFWrapper extends PDF
         }
 
         return $html;
+    }
+
+    /**
+     * @param  array<string, mixed>  $variables
+     * @return array<string, mixed>
+     */
+    protected function withoutReserved(array $variables): array
+    {
+        return array_diff_key($variables, array_flip(self::RESERVED_VARIABLES));
     }
 
     /**
@@ -294,6 +310,14 @@ class PDFWrapper extends PDF
      * @param  array<string, mixed>  $data
      */
     public function parseLayout(Layout $layout, array $data = []): string
+    {
+        return $this->renderWithEvents($layout, $data, fn (array $data): string => $this->renderLayout($layout, $data));
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function renderLayout(Layout $layout, array $data): string
     {
         return $this->parseMarkup(
             $layout->content_html,

--- a/console/Check.php
+++ b/console/Check.php
@@ -38,8 +38,8 @@ class Check extends Command
 
         $this->remote(config('dompdf.options.enable_remote'), config('dompdf.options.allowed_remote_hosts'));
 
-        $this->views('Registered layouts', PDFManager::instance()->listRegisteredLayouts() ?? []);
-        $this->views('Registered templates', PDFManager::instance()->listRegisteredTemplates() ?? []);
+        $this->views('Registered layouts', PDFManager::instance()->listRegisteredLayouts());
+        $this->views('Registered templates', PDFManager::instance()->listRegisteredTemplates());
 
         $this->newLine();
 

--- a/models/Layout.php
+++ b/models/Layout.php
@@ -68,7 +68,7 @@ class Layout extends Model
             return $layout;
         }
 
-        if (! array_key_exists($code, PDFManager::instance()->listRegisteredLayouts() ?? [])) {
+        if (! array_key_exists($code, PDFManager::instance()->listRegisteredLayouts())) {
             throw (new ModelNotFoundException)->setModel(static::class, [$code]);
         }
 

--- a/models/Template.php
+++ b/models/Template.php
@@ -162,7 +162,7 @@ class Template extends Model
             return $template;
         }
 
-        if (! array_key_exists($code, PDFManager::instance()->listRegisteredTemplates() ?? [])) {
+        if (! array_key_exists($code, PDFManager::instance()->listRegisteredTemplates())) {
             throw (new ModelNotFoundException)->setModel(static::class, [$code]);
         }
 

--- a/tests/Unit/Classes/VariablesAndEventsTest.php
+++ b/tests/Unit/Classes/VariablesAndEventsTest.php
@@ -36,6 +36,22 @@ describe('Global variables and events', function () {
         expect(app('dynamicpdf')->parseTemplate($template))->toBe('<p>COPY</p><!-- audited -->');
     });
 
+    it('keeps plugin registrations when a variable was registered before the plugins were read', function () {
+        PDFManager::instance()->registerVariables(['company' => 'Acme']);
+
+        expect(PDFManager::instance()->listRegisteredVariables())->toHaveKey('company')
+            ->and(PDFManager::instance()->listRegisteredTemplates())->toBeArray();
+    });
+
+    it('ignores reserved names coming from variables and listeners', function () {
+        PDFManager::instance()->registerVariables(['content_html' => 'hijacked', 'css' => 'hijacked']);
+        Event::listen(Events::BEFORE_RENDER, fn (): array => ['content_html' => 'hijacked']);
+        $layout = $this->createLayout(['content_html' => '<html><body>{{ content_html|raw }}</body></html>']);
+        $template = $this->createTemplate(['content_html' => '<p>real</p>', 'layout_id' => $layout->id]);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toBe('<html><body><p>real</p></body></html>');
+    });
+
     it('fires the events for a layout loaded on its own', function () {
         Event::listen(Events::BEFORE_RENDER, fn (): array => ['stamp' => 'LAYOUT']);
         $this->createLayout(['code' => 'acme::pdf.layouts.stamp', 'content_html' => '<html><body>{{ stamp }}</body></html>']);

--- a/tests/Unit/Classes/VariablesAndEventsTest.php
+++ b/tests/Unit/Classes/VariablesAndEventsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Renatio\DynamicPDF\Classes\Events;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\PDFWrapper;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Global variables and events', function () {
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        Event::forget(Events::BEFORE_RENDER);
+        Event::forget(Events::AFTER_RENDER);
+    });
+
+    it('exposes registered variables to templates and layouts, resolving closures lazily', function () {
+        PDFManager::instance()->registerVariables(['company' => 'Acme', 'year' => fn (): string => '2026']);
+        $layout = $this->createLayout(['content_html' => '<html><body>{{ company }} {{ content_html|raw }}</body></html>']);
+        $template = $this->createTemplate(['content_html' => '<p>{{ year }} {{ company }}</p>', 'layout_id' => $layout->id]);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toBe('<html><body>Acme <p>2026 Acme</p></body></html>');
+    });
+
+    it('lets render data override a registered variable', function () {
+        PDFManager::instance()->registerVariables(['company' => 'Acme']);
+        $template = $this->createTemplate(['content_html' => '{{ company }}']);
+
+        expect(app('dynamicpdf')->parseTemplate($template, ['company' => 'Other']))->toBe('Other');
+    });
+
+    it('lets a beforeRender listener add data and an afterRender listener change the HTML', function () {
+        Event::listen(Events::BEFORE_RENDER, fn (PDFWrapper $pdf, Template $template, array $data): array => ['stamp' => 'COPY']);
+        Event::listen(Events::AFTER_RENDER, fn (PDFWrapper $pdf, Template $template, string $html): string => $html . '<!-- audited -->');
+        $template = $this->createTemplate(['content_html' => '<p>{{ stamp }}</p>']);
+
+        expect(app('dynamicpdf')->parseTemplate($template))->toBe('<p>COPY</p><!-- audited -->');
+    });
+
+    it('fires the events for a layout loaded on its own', function () {
+        Event::listen(Events::BEFORE_RENDER, fn (): array => ['stamp' => 'LAYOUT']);
+        $this->createLayout(['code' => 'acme::pdf.layouts.stamp', 'content_html' => '<html><body>{{ stamp }}</body></html>']);
+
+        expect(app('dynamicpdf')->loadLayout('acme::pdf.layouts.stamp')->getDomPDF()->outputHtml())->toContain('LAYOUT');
+    });
+});

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -72,4 +72,5 @@ v8.0.4:
     - Add pageNumbers() to stamp page numbers without inline PHP.
     - Add the dynamicpdf:sync and dynamicpdf:check console commands.
     - Add toFile() and a chainable encrypt().
+    - Add registerPDFVariables() and the beforeRender and afterRender events.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Zakres
- `registerPDFVariables()` w `Plugin.php` dowolnego pluginu (zbierane przez `PDFManager`, jak `registerPDFTemplates`) — zmienne dokładane pod dane każdego renderu; wartość-closure rozwiązywana przy renderze; dane przekazane do `loadTemplate()`/`parseTemplate()` mają pierwszeństwo,
- zdarzenia `renatio.dynamicpdf.beforeRender` (`$pdf, $model, $data` → tablica scalana na dane) i `renatio.dynamicpdf.afterRender` (`$pdf, $model, $html` → string zastępujący HTML), stałe w `Classes\Events`,
- oba fire'owane raz na dokument: w `parseTemplate()` (szablon razem z layoutem) oraz w `loadLayout()` dla layoutu samodzielnego,
- README: sekcje *Global variables* i *Events*; `version.yaml`.

## Testy
`tests/Unit/Classes/VariablesAndEventsTest.php`: zmienne w szablonie i layoucie z leniwym closure, pierwszeństwo danych renderu, listener beforeRender dodaje dane, afterRender podmienia HTML, zdarzenia dla samodzielnego layoutu.

Closes #134
