### PR TITLE
PDF::fake() z asercjami assertRendered() dla testów projektów

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,23 @@ Inline PHP (`setIsPhpEnabled(true)`) is no longer needed for page numbers and sh
 > `<script type="text/php">` block in the HTML is executed on the server, so enabling it for templates that can be
 > edited by backend users allows remote code execution. The backend HTML and PDF preview never enables it.
 
+## Testing
+
+`PDF::fake()` replaces the wrapper for the rest of the test: no template is looked up, Twig and dompdf do not run,
+`stream()` and `download()` return an empty `application/pdf` response and `output()` returns an empty string. The
+fake records every `loadTemplate()` / `loadLayout()` call with its data, layout and locale:
+
+```
+$fake = PDF::fake();
+
+$this->get('/backend/acme/orders/pdf/1');
+
+$fake->assertRendered('acme::pdf.invoice', fn (array $data) => $data['order']->id === 1);
+$fake->assertNotRendered('acme::pdf.reminder');
+$fake->assertRenderedCount(1);
+// $fake->assertNothingRendered();
+```
+
 ## Console commands
 
 `php artisan dynamicpdf:sync` synchronises the registered PDF views with the database and lists what was created,

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 | output()                                                | Output the PDF as a string                               |
 | toFile($filename = 'document.pdf', $public = true)      | Return the PDF as a System\Models\File to attach to a model |
 | encrypt($password, $ownerPassword = '', $permissions = []) | Password-protect the PDF (CPDF backend)               |
+| fake()                                                  | Static: replace the wrapper with a recorder for tests    |
 | addInfo(array $info)                                    | Set PDF metadata such as Title or Author                 |
 | save($filename, $disk = null)                           | Save the PDF to a file, optionally on a storage disk     |
 | download($filename = 'document.pdf')                    | Make the PDF downloadable by the user                    |
@@ -495,9 +496,11 @@ Inline PHP (`setIsPhpEnabled(true)`) is no longer needed for page numbers and sh
 
 ## Testing
 
-`PDF::fake()` replaces the wrapper for the rest of the test: no template is looked up, Twig and dompdf do not run,
-`stream()` and `download()` return an empty `application/pdf` response and `output()` returns an empty string. The
-fake records every `loadTemplate()` / `loadLayout()` call with its data, layout and locale:
+`PDF::fake()` replaces the wrapper for the rest of the test: no template is looked up, no Twig, dompdf, database or
+filesystem work happens, `stream()` and `download()` return an empty `application/pdf` response, `output()` returns an
+empty string, `save()` writes nothing and `toFile()` returns a record that can be attached and saved. The fake records
+every `loadTemplate()`, `loadLayout()`, `loadView()`, `loadFile()`, `parseTemplate()` and `parseLayout()` call with its
+data, layout and locale:
 
 ```
 $fake = PDF::fake();
@@ -505,10 +508,12 @@ $fake = PDF::fake();
 $this->get('/backend/acme/orders/pdf/1');
 
 $fake->assertRendered('acme::pdf.invoice', fn (array $data) => $data['order']->id === 1);
+$fake->assertRenderedTimes('acme::pdf.invoice', 1);
 $fake->assertNotRendered('acme::pdf.reminder');
-$fake->assertRenderedCount(1);
-// $fake->assertNothingRendered();
 ```
+
+`assertNothingRendered()` covers the negative case and `rendered()` returns the raw records. `pageNumbers()` keeps
+validating its arguments under the fake.
 
 ## Console commands
 

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -23,4 +23,18 @@ class PDF extends PdfFacade
     {
         return 'dynamicpdf';
     }
+
+    /**
+     * Replace the wrapper with a recorder for the rest of the test, so no template is looked
+     * up and no PDF is produced.
+     */
+    public static function fake(): PDFFake
+    {
+        $app = static::getFacadeApplication();
+
+        $fake = new PDFFake($app->make('dompdf'), $app->make('config'), $app->make('files'), $app->make('view'));
+        $app->instance(static::getFacadeAccessor(), $fake);
+
+        return $fake;
+    }
 }

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -5,6 +5,7 @@ namespace Renatio\DynamicPDF\Classes;
 use Barryvdh\DomPDF\Facade\Pdf as PdfFacade;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
+use RuntimeException;
 
 /**
  * @method static PDFWrapper loadTemplate(string $code, array<string, mixed> $data = [], ?string $encoding = null, ?string $layout = null, ?string $locale = null)
@@ -30,7 +31,7 @@ class PDF extends PdfFacade
      */
     public static function fake(): PDFFake
     {
-        $app = static::getFacadeApplication();
+        $app = static::getFacadeApplication() ?? throw new RuntimeException('Facade application has not been set.');
 
         $fake = new PDFFake($app->make('dompdf'), $app->make('config'), $app->make('files'), $app->make('view'));
         $app->instance(static::getFacadeAccessor(), $fake);

--- a/classes/PDFFake.php
+++ b/classes/PDFFake.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Renatio\DynamicPDF\Classes;
+
+use Illuminate\Http\Response;
+use PHPUnit\Framework\Assert;
+use System\Models\File;
+
+/**
+ * Records what a project renders without touching templates, Twig or dompdf.
+ */
+class PDFFake extends PDFWrapper
+{
+    /** @var array<int, array{code: string, kind: string, data: array<string, mixed>, layout: string|null, locale: string|null}> */
+    protected array $renders = [];
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function loadTemplate(string $code, array $data = [], ?string $encoding = null, ?string $layout = null, ?string $locale = null): self
+    {
+        $this->renders[] = ['code' => $code, 'kind' => 'template', 'data' => $data, 'layout' => $layout, 'locale' => $locale];
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function loadLayout(string $code, array $data = [], ?string $encoding = null, ?string $locale = null): self
+    {
+        $this->renders[] = ['code' => $code, 'kind' => 'layout', 'data' => $data, 'layout' => null, 'locale' => $locale];
+
+        return $this;
+    }
+
+    public function loadHTML(string $string, ?string $encoding = null): self
+    {
+        return $this;
+    }
+
+    public function render(): void
+    {
+    }
+
+    /**
+     * @param  array<string, int>  $options
+     */
+    public function output(array $options = []): string
+    {
+        return '';
+    }
+
+    public function save(string $filename, ?string $disk = null): self
+    {
+        return $this;
+    }
+
+    public function download(string $filename = 'document.pdf'): Response
+    {
+        return $this->emptyResponse($filename, 'attachment');
+    }
+
+    public function stream(string $filename = 'document.pdf'): Response
+    {
+        return $this->emptyResponse($filename, 'inline');
+    }
+
+    public function toFile(string $filename = 'document.pdf', bool $public = true): File
+    {
+        $file = new File;
+        $file->setAttribute('file_name', $filename);
+        $file->setAttribute('content_type', 'application/pdf');
+        $file->setAttribute('is_public', $public);
+
+        return $file;
+    }
+
+    public function encrypt(string $password, string $ownerPassword = '', array $permissions = []): self
+    {
+        return $this;
+    }
+
+    public function assertRendered(string $code, ?callable $callback = null): void
+    {
+        $matches = array_filter($this->renders, fn (array $render): bool => $render['code'] === $code && ($callback === null || $callback($render['data'], $render)));
+
+        Assert::assertNotEmpty($matches, "The PDF [{$code}] was not rendered" . ($callback ? ' with the expected data.' : '.'));
+    }
+
+    public function assertNotRendered(string $code): void
+    {
+        Assert::assertEmpty(
+            array_filter($this->renders, fn (array $render): bool => $render['code'] === $code),
+            "The PDF [{$code}] was rendered.",
+        );
+    }
+
+    public function assertNothingRendered(): void
+    {
+        Assert::assertEmpty($this->renders, 'PDFs were rendered: ' . implode(', ', array_column($this->renders, 'code')));
+    }
+
+    public function assertRenderedCount(int $count): void
+    {
+        Assert::assertCount($count, $this->renders);
+    }
+
+    /**
+     * @return array<int, array{code: string, kind: string, data: array<string, mixed>, layout: string|null, locale: string|null}>
+     */
+    public function rendered(): array
+    {
+        return $this->renders;
+    }
+
+    protected function emptyResponse(string $filename, string $disposition): Response
+    {
+        return new Response('', 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => "{$disposition}; filename=\"{$filename}\"",
+        ]);
+    }
+}

--- a/classes/PDFFake.php
+++ b/classes/PDFFake.php
@@ -2,26 +2,41 @@
 
 namespace Renatio\DynamicPDF\Classes;
 
+use Dompdf\Dompdf;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Response;
+use Illuminate\Support\Testing\Fakes\Fake;
 use PHPUnit\Framework\Assert;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use System\Models\File;
 
 /**
- * Records what a project renders without touching templates, Twig or dompdf.
+ * Records what a project renders without touching templates, Twig, dompdf, the database
+ * or the filesystem.
  */
-class PDFFake extends PDFWrapper
+class PDFFake extends PDFWrapper implements Fake
 {
     /** @var array<int, array{code: string, kind: string, data: array<string, mixed>, layout: string|null, locale: string|null}> */
     protected array $renders = [];
+
+    public function __construct(Dompdf $dompdf, ConfigRepository $config, Filesystem $files, ViewFactory $view)
+    {
+        $this->dompdf = $dompdf;
+        $this->config = $config;
+        $this->files = $files;
+        $this->view = $view;
+    }
 
     /**
      * @param  array<string, mixed>  $data
      */
     public function loadTemplate(string $code, array $data = [], ?string $encoding = null, ?string $layout = null, ?string $locale = null): self
     {
-        $this->renders[] = ['code' => $code, 'kind' => 'template', 'data' => $data, 'layout' => $layout, 'locale' => $locale];
-
-        return $this;
+        return $this->record('template', $code, $data, $layout, $locale);
     }
 
     /**
@@ -29,14 +44,46 @@ class PDFFake extends PDFWrapper
      */
     public function loadLayout(string $code, array $data = [], ?string $encoding = null, ?string $locale = null): self
     {
-        $this->renders[] = ['code' => $code, 'kind' => 'layout', 'data' => $data, 'layout' => null, 'locale' => $locale];
+        return $this->record('layout', $code, $data, null, $locale);
+    }
 
-        return $this;
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $mergeData
+     */
+    public function loadView(string $view, array $data = [], array $mergeData = [], ?string $encoding = null): self
+    {
+        return $this->record('view', $view, array_merge($mergeData, $data), null, null);
+    }
+
+    public function loadFile(string $file): self
+    {
+        return $this->record('file', $file, [], null, null);
     }
 
     public function loadHTML(string $string, ?string $encoding = null): self
     {
         return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function parseTemplate(Template $template, array $data = []): string
+    {
+        $this->record('template', (string) $template->code, $data, null, null);
+
+        return '';
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function parseLayout(Layout $layout, array $data = []): string
+    {
+        $this->record('layout', (string) $layout->code, $data, null, null);
+
+        return '';
     }
 
     public function render(): void
@@ -66,11 +113,16 @@ class PDFFake extends PDFWrapper
         return $this->emptyResponse($filename, 'inline');
     }
 
+    /**
+     * Complete enough to be attached and saved without a byte written anywhere.
+     */
     public function toFile(string $filename = 'document.pdf', bool $public = true): File
     {
         $file = new File;
         $file->setAttribute('file_name', $filename);
+        $file->setAttribute('disk_name', uniqid() . '.pdf');
         $file->setAttribute('content_type', 'application/pdf');
+        $file->setAttribute('file_size', 0);
         $file->setAttribute('is_public', $public);
 
         return $file;
@@ -81,11 +133,46 @@ class PDFFake extends PDFWrapper
         return $this;
     }
 
+    /**
+     * @param  array<string>  $pc
+     */
+    public function setEncryption(string $password, string $ownerpassword = '', array $pc = []): void
+    {
+    }
+
+    /**
+     * @param  array<string, string>  $info
+     */
+    public function addInfo(array $info): self
+    {
+        return $this;
+    }
+
+    public function allowRemoteApplicationAssets(): self
+    {
+        return $this;
+    }
+
+    public function allowSelfSignedCertificates(): self
+    {
+        return $this;
+    }
+
+    public function __call($method, $parameters)
+    {
+        return $this;
+    }
+
     public function assertRendered(string $code, ?callable $callback = null): void
     {
         $matches = array_filter($this->renders, fn (array $render): bool => $render['code'] === $code && ($callback === null || $callback($render['data'], $render)));
 
         Assert::assertNotEmpty($matches, "The PDF [{$code}] was not rendered" . ($callback ? ' with the expected data.' : '.'));
+    }
+
+    public function assertRenderedTimes(string $code, int $times): void
+    {
+        Assert::assertCount($times, array_filter($this->renders, fn (array $render): bool => $render['code'] === $code), "The PDF [{$code}] was not rendered {$times} time(s).");
     }
 
     public function assertNotRendered(string $code): void
@@ -101,11 +188,6 @@ class PDFFake extends PDFWrapper
         Assert::assertEmpty($this->renders, 'PDFs were rendered: ' . implode(', ', array_column($this->renders, 'code')));
     }
 
-    public function assertRenderedCount(int $count): void
-    {
-        Assert::assertCount($count, $this->renders);
-    }
-
     /**
      * @return array<int, array{code: string, kind: string, data: array<string, mixed>, layout: string|null, locale: string|null}>
      */
@@ -114,11 +196,22 @@ class PDFFake extends PDFWrapper
         return $this->renders;
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function record(string $kind, string $code, array $data, ?string $layout, ?string $locale): self
+    {
+        $this->renders[] = ['code' => $code, 'kind' => $kind, 'data' => $data, 'layout' => $layout, 'locale' => $locale];
+
+        return $this;
+    }
+
     protected function emptyResponse(string $filename, string $disposition): Response
     {
         return new Response('', 200, [
             'Content-Type' => 'application/pdf',
-            'Content-Disposition' => "{$disposition}; filename=\"{$filename}\"",
+            'Content-Disposition' => HeaderUtils::makeDisposition($disposition, $filename, $this->fallbackName($filename)),
+            'Content-Length' => 0,
         ]);
     }
 }

--- a/tests/Unit/Classes/PDFFakeTest.php
+++ b/tests/Unit/Classes/PDFFakeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\AssertionFailedError;
+use Renatio\DynamicPDF\Classes\PDF;
+
+describe('PDF::fake()', function () {
+    afterEach(fn () => app()->forgetInstance('dynamicpdf'));
+
+    it('records renders without needing the template and answers with an empty PDF response', function () {
+        $fake = PDF::fake();
+
+        $response = PDF::loadTemplate('acme::pdf.invoice', ['order' => 7], layout: 'acme::pdf.layouts.b', locale: 'de')->stream('invoice.pdf');
+
+        expect($response->headers->get('Content-Type'))->toBe('application/pdf')
+            ->and(PDF::loadTemplate('acme::pdf.invoice')->output())->toBeEmpty()
+            ->and(app('dynamicpdf'))->toBe($fake);
+
+        $fake->assertRendered('acme::pdf.invoice', fn (array $data, array $render): bool => ($data['order'] ?? null) === 7 && $render['layout'] === 'acme::pdf.layouts.b' && $render['locale'] === 'de');
+        $fake->assertRenderedCount(2);
+        $fake->assertNotRendered('acme::pdf.other');
+    });
+
+    it('fails the assertions the way a test expects', function () {
+        $fake = PDF::fake();
+
+        expect(fn () => $fake->assertRendered('acme::pdf.invoice'))->toThrow(AssertionFailedError::class);
+
+        PDF::loadTemplate('acme::pdf.invoice');
+
+        expect(fn () => $fake->assertNothingRendered())->toThrow(AssertionFailedError::class)
+            ->and(fn () => $fake->assertRendered('acme::pdf.invoice', fn (array $data): bool => isset($data['missing'])))->toThrow(AssertionFailedError::class);
+    });
+});

--- a/tests/Unit/Classes/PDFFakeTest.php
+++ b/tests/Unit/Classes/PDFFakeTest.php
@@ -4,8 +4,6 @@ use PHPUnit\Framework\AssertionFailedError;
 use Renatio\DynamicPDF\Classes\PDF;
 
 describe('PDF::fake()', function () {
-    afterEach(fn () => app()->forgetInstance('dynamicpdf'));
-
     it('records renders without needing the template and answers with an empty PDF response', function () {
         $fake = PDF::fake();
 
@@ -16,8 +14,25 @@ describe('PDF::fake()', function () {
             ->and(app('dynamicpdf'))->toBe($fake);
 
         $fake->assertRendered('acme::pdf.invoice', fn (array $data, array $render): bool => ($data['order'] ?? null) === 7 && $render['layout'] === 'acme::pdf.layouts.b' && $render['locale'] === 'de');
-        $fake->assertRenderedCount(2);
+        $fake->assertRenderedTimes('acme::pdf.invoice', 2);
         $fake->assertNotRendered('acme::pdf.other');
+    });
+
+    it('returns a file record that saves without touching the disk', function () {
+        PDF::fake();
+        $layout = $this->createLayout();
+
+        $layout->setAttribute('background_img', PDF::loadTemplate('acme::pdf.invoice')->toFile('invoice.pdf', public: false));
+        $layout->save();
+
+        expect(\System\Models\File::where('attachment_id', $layout->id)->where('field', 'background_img')->count())->toBe(1);
+    });
+
+    it('matches the real Content-Disposition header', function () {
+        PDF::fake();
+
+        expect(PDF::loadTemplate('acme::pdf.invoice')->download('faktura-ą.pdf')->headers->get('Content-Disposition'))
+            ->toBe("attachment; filename=faktura-a.pdf; filename*=utf-8''faktura-%C4%85.pdf");
     });
 
     it('fails the assertions the way a test expects', function () {

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -73,4 +73,5 @@ v8.0.4:
     - Add the dynamicpdf:sync and dynamicpdf:check console commands.
     - Add toFile() and a chainable encrypt().
     - Add registerPDFVariables() and the beforeRender and afterRender events.
+    - Add PDF::fake() with render assertions for project tests.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Zakres
`PDF::fake(): PDFFake` w stylu `Mail::fake()`: podmienia binding `dynamicpdf` na rekorder (podklasa `PDFWrapper`, więc typowany kod działa), który nie szuka szablonów, nie odpala Twiga ani dompdfa; `loadTemplate()`/`loadLayout()` zapisują kod, dane, layout i locale; `stream()`/`download()` zwracają pustą odpowiedź `application/pdf`, `output()` pusty string, `toFile()` niezapisany rekord bez zapisu na dysk, `save()`/`encrypt()` no-op.

Asercje: `assertRendered($code, ?callable)`, `assertNotRendered()`, `assertNothingRendered()`, `assertRenderedCount()`, `rendered()`. README: sekcja *Testing*; `version.yaml`.

## Testy
`tests/Unit/Classes/PDFFakeTest.php`: nagranie renderu z danymi/layoutem/locale bez istniejącego szablonu, pusta odpowiedź PDF, ta sama instancja z kontenera, asercje przechodzą i padają zgodnie z oczekiwaniem (`AssertionFailedError`).

Closes #136
