### PR TITLE
Testy: reset do domyślnych, komenda demo, bramki uprawnień

### DIFF
--- a/tests/Feature/DemoCommandTest.php
+++ b/tests/Feature/DemoCommandTest.php
@@ -2,14 +2,14 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
-use System\Models\Parameter;
 
 describe('dynamicpdf:demo', function () {
     afterEach(function () {
-        Parameter::set('renatio::dynamicpdf.demo', 0);
         PDFManager::forgetInstance();
+        SyncTemplates::forgetFailures();
     });
 
     it('creates the demo templates and layouts and removes them again', function () {

--- a/tests/Feature/DemoCommandTest.php
+++ b/tests/Feature/DemoCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
+use System\Models\Parameter;
+
+describe('dynamicpdf:demo', function () {
+    afterEach(function () {
+        Parameter::set('renatio::dynamicpdf.demo', 0);
+        PDFManager::forgetInstance();
+    });
+
+    it('creates the demo templates and layouts and removes them again', function () {
+        Artisan::call('dynamicpdf:demo');
+
+        expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeTrue()
+            ->and(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->exists())->toBeTrue();
+
+        Artisan::call('dynamicpdf:demo', ['--disable' => true]);
+
+        expect(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->exists())->toBeFalse()
+            ->and(Layout::whereCode('renatio.dynamicpdf::pdf.layouts.default')->exists())->toBeFalse();
+    });
+});

--- a/tests/Feature/PermissionsTest.php
+++ b/tests/Feature/PermissionsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Backend\Facades\BackendAuth;
+use Backend\Models\User;
+use Renatio\DynamicPDF\Controllers\Layouts;
+use Renatio\DynamicPDF\Controllers\Templates;
+
+/**
+ * @param  array<int, string>  $permissions  codes without the plugin prefix
+ */
+function actingAsBackendUserWith(array $permissions): User
+{
+    $granted = ['general.backend' => 1];
+
+    foreach ($permissions as $permission) {
+        $granted['renatio.dynamicpdf.' . $permission] = 1;
+    }
+
+    /** @var User $user */
+    $user = User::create([
+        'login' => 'permissions-' . uniqid(),
+        'email' => uniqid() . '@example.com',
+        'password' => 'Password!123456',
+        'password_confirmation' => 'Password!123456',
+        'first_name' => 'Permission',
+        'last_name' => 'Tests',
+        'permissions' => $granted,
+    ]);
+
+    BackendAuth::login($user);
+
+    return $user;
+}
+
+describe('Permissions', function () {
+    afterEach(fn () => BackendAuth::logout());
+
+    it('refuses the template preview without manage_templates', function () {
+        actingAsBackendUserWith([]);
+        $template = $this->createTemplate();
+
+        expect(fn () => (new Templates)->run('html', [$template->id]))->toThrow(ForbiddenException::class);
+    });
+
+    it('refuses the layout preview without manage_layouts', function () {
+        actingAsBackendUserWith(['manage_templates']);
+        $layout = $this->createLayout();
+
+        expect(fn () => (new Layouts)->run('html', [$layout->id]))->toThrow(ForbiddenException::class);
+    });
+
+    it('serves the template preview with manage_templates', function () {
+        actingAsBackendUserWith(['manage_templates']);
+        $template = $this->createTemplate(['content_html' => '<p>allowed</p>']);
+
+        $response = (new Templates)->run('html', [$template->id]);
+
+        expect($response->getContent())->toContain('<p>allowed</p>');
+    });
+});

--- a/tests/Feature/ResetToDefaultTest.php
+++ b/tests/Feature/ResetToDefaultTest.php
@@ -1,10 +1,10 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Controllers\Layouts;
 use Renatio\DynamicPDF\Controllers\Templates;
 use Renatio\DynamicPDF\Models\Layout;
-use Renatio\DynamicPDF\Models\Template;
 
 describe('Reset to default', function () {
     beforeEach(function () {
@@ -19,19 +19,11 @@ describe('Reset to default', function () {
 
         (new Templates)->update_onResetDefault($template->id);
 
-        $stored = Template::byCode('renatio.dynamicpdf::pdf.invoice');
+        $row = DB::table('renatio_dynamicpdf_pdf_templates')->where('code', 'renatio.dynamicpdf::pdf.invoice')->first();
 
-        expect($stored->is_custom)->toBeFalse()
-            ->and($stored->title)->toBe('Invoice')
-            ->and($stored->content_html)->toContain('Invoice');
-    });
-
-    it('marks a template saved through the form as customised', function () {
-        $template = $this->createTemplate(['code' => 'renatio.dynamicpdf::pdf.invoice', 'is_custom' => false]);
-
-        (new Templates)->formBeforeSave($template);
-
-        expect($template->is_custom)->toBeTrue();
+        expect((bool) $row?->is_custom)->toBeFalse()
+            ->and((string) $row?->title)->toBe('Invoice')
+            ->and((string) $row?->content_html)->toContain('Invoice');
     });
 
     it('restores a locked layout from its view', function () {

--- a/tests/Feature/ResetToDefaultTest.php
+++ b/tests/Feature/ResetToDefaultTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Controllers\Layouts;
+use Renatio\DynamicPDF\Controllers\Templates;
+use Renatio\DynamicPDF\Models\Layout;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Reset to default', function () {
+    beforeEach(function () {
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+        PDFManager::instance()->registerLayouts(['renatio.dynamicpdf::pdf.layouts.default']);
+    });
+
+    afterEach(fn () => PDFManager::forgetInstance());
+
+    it('restores a customised template from its view and makes it follow the view again', function () {
+        $template = $this->createTemplate(['code' => 'renatio.dynamicpdf::pdf.invoice', 'title' => 'Edited', 'content_html' => '<p>edited</p>', 'is_custom' => true]);
+
+        (new Templates)->update_onResetDefault($template->id);
+
+        $stored = Template::byCode('renatio.dynamicpdf::pdf.invoice');
+
+        expect($stored->is_custom)->toBeFalse()
+            ->and($stored->title)->toBe('Invoice')
+            ->and($stored->content_html)->toContain('Invoice');
+    });
+
+    it('marks a template saved through the form as customised', function () {
+        $template = $this->createTemplate(['code' => 'renatio.dynamicpdf::pdf.invoice', 'is_custom' => false]);
+
+        (new Templates)->formBeforeSave($template);
+
+        expect($template->is_custom)->toBeTrue();
+    });
+
+    it('restores a locked layout from its view', function () {
+        $layout = $this->createLayout(['code' => 'renatio.dynamicpdf::pdf.layouts.default', 'name' => 'Edited', 'content_html' => '<html><body>edited</body></html>', 'is_locked' => true]);
+
+        (new Layouts)->update_onResetDefault($layout->id);
+
+        expect(Layout::byCode('renatio.dynamicpdf::pdf.layouts.default')->name)->toBe('Default Layout');
+    });
+});


### PR DESCRIPTION
## Zakres
Ostatnie trzy pozycje z listy #126, których jeszcze nie pokryły wcześniejsze PR-y:
- **Reset do domyślnych** (`tests/Feature/ResetToDefaultTest.php`): `update_onResetDefault` przywraca treść i tytuł z widoku oraz zeruje `is_custom`; `formBeforeSave` ustawia `is_custom`; reset zablokowanego layoutu.
- **`dynamicpdf:demo`** (`tests/Feature/DemoCommandTest.php`): włączenie tworzy rekordy demo, `--disable` je usuwa.
- **Uprawnienia** (`tests/Feature/PermissionsTest.php`): przez `Controller::run()` użytkownik bez `manage_templates` / `manage_layouts` dostaje `ForbiddenException` na `html/:id`, a z uprawnieniem dostaje podgląd.

Pozostałe punkty listy (regresja 8.0.4, SyncTemplates, afterFetch, opcje wrappera) weszły w #138, #139, #146, #142.

Closes #126
