### PR TITLE
Unikalny indeks na code szablonów i layoutów z deduplikacją

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,12 +85,16 @@ TLS certificates are verified on every environment. On a development host with a
 `DYNAMICPDF_ALLOW_SELF_SIGNED=true` in `.env` (or `allow_self_signed_certificates` in `config/renatio/dynamicpdf.php`),
 or call the now public `allowSelfSignedCertificates()` on the wrapper for a single document.
 
-The template and layout `code` columns get a unique index. Duplicate rows, which concurrent synchronisations could
-leave behind, are removed by the migration: the customised (or locked) row is kept, otherwise the oldest one.
-
 Registered PDF views are synchronised to the database when the *PDF Templates* settings page is opened or
 `dynamicpdf:demo` runs, no longer on every request. Rendering a registered view that is not stored yet works without
 the sync. A registered code without a view file is skipped and logged instead of silently stopping the sync.
 
 The backend HTML and PDF preview no longer enables inline PHP. If you use the demo templates, open the
 **Header and Footer** layout and click **Reset to default** to remove the page number script from the stored copy.
+
+## Upgrading To 8.0.5
+
+The template and layout `code` columns get a unique index. Duplicate rows, which concurrent synchronisations could
+leave behind, are deleted permanently by the migration and not restored by a rollback: for templates the customised
+row is kept, for layouts the locked one, otherwise the oldest. Templates attached to a deleted layout are re-pointed
+to the kept one.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -85,6 +85,9 @@ TLS certificates are verified on every environment. On a development host with a
 `DYNAMICPDF_ALLOW_SELF_SIGNED=true` in `.env` (or `allow_self_signed_certificates` in `config/renatio/dynamicpdf.php`),
 or call the now public `allowSelfSignedCertificates()` on the wrapper for a single document.
 
+The template and layout `code` columns get a unique index. Duplicate rows, which concurrent synchronisations could
+leave behind, are removed by the migration: the customised (or locked) row is kept, otherwise the oldest one.
+
 Registered PDF views are synchronised to the database when the *PDF Templates* settings page is opened or
 `dynamicpdf:demo` runs, no longer on every request. Rendering a registered view that is not stored yet works without
 the sync. A registered code without a view file is skipped and logged instead of silently stopping the sync.

--- a/classes/SyncTemplates.php
+++ b/classes/SyncTemplates.php
@@ -2,6 +2,7 @@
 
 namespace Renatio\DynamicPDF\Classes;
 
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Log;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
@@ -109,6 +110,8 @@ class SyncTemplates
         try {
             $create();
             $this->report['created'][] = $code;
+        } catch (UniqueConstraintViolationException) {
+            // Another request synced the same code a moment earlier; the row exists.
         } catch (Throwable $e) {
             self::$failed[$code] = true;
             $this->report['failed'][] = $code;

--- a/tests/Feature/ResetToDefaultTest.php
+++ b/tests/Feature/ResetToDefaultTest.php
@@ -21,7 +21,7 @@ describe('Reset to default', function () {
 
         $row = DB::table('renatio_dynamicpdf_pdf_templates')->where('code', 'renatio.dynamicpdf::pdf.invoice')->first();
 
-        expect((bool) $row?->is_custom)->toBeFalse()
+        expect($row?->is_custom)->toBeFalsy()
             ->and((string) $row?->title)->toBe('Invoice')
             ->and((string) $row?->content_html)->toContain('Invoice');
     });

--- a/tests/Unit/Classes/ConcurrentSyncTest.php
+++ b/tests/Unit/Classes/ConcurrentSyncTest.php
@@ -6,6 +6,11 @@ use Renatio\DynamicPDF\Classes\SyncTemplates;
 use Renatio\DynamicPDF\Models\Template;
 
 describe('Unique codes', function () {
+    beforeEach(function () {
+        PDFManager::forgetInstance();
+        SyncTemplates::forgetFailures();
+    });
+
     afterEach(function () {
         PDFManager::forgetInstance();
         SyncTemplates::forgetFailures();

--- a/tests/Unit/Classes/ConcurrentSyncTest.php
+++ b/tests/Unit/Classes/ConcurrentSyncTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Renatio\DynamicPDF\Classes\PDFManager;
+use Renatio\DynamicPDF\Classes\SyncTemplates;
+use Renatio\DynamicPDF\Models\Template;
+
+describe('Unique codes', function () {
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        SyncTemplates::forgetFailures();
+    });
+
+    it('stores a code once even when two syncs race', function () {
+        PDFManager::instance()->registerTemplates(['renatio.dynamicpdf::pdf.invoice']);
+        (new SyncTemplates)->handle();
+
+        $late = new Template;
+        $late->fillFromView('renatio.dynamicpdf::pdf.invoice');
+
+        expect(fn () => $late->forceSave())->toThrow(Illuminate\Database\QueryException::class)
+            ->and(Template::whereCode('renatio.dynamicpdf::pdf.invoice')->count())->toBe(1);
+    });
+
+    it('refuses a duplicate layout code at the database level', function () {
+        $this->createLayout(['code' => 'acme::pdf.layouts.default']);
+
+        expect(fn () => DB::table('renatio_dynamicpdf_pdf_layouts')->insert(['code' => 'acme::pdf.layouts.default', 'name' => 'Twin', 'content_html' => '<p></p>']))
+            ->toThrow(Illuminate\Database\QueryException::class);
+    });
+});

--- a/updates/20260907_0002_add_unique_code_indexes.php
+++ b/updates/20260907_0002_add_unique_code_indexes.php
@@ -4,13 +4,14 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
+use Renatio\DynamicPDF\Models\Layout;
 
 return new class extends Migration
 {
     public function up()
     {
-        $this->deduplicate('renatio_dynamicpdf_pdf_templates', 'is_custom');
-        $this->deduplicate('renatio_dynamicpdf_pdf_layouts', 'is_locked');
+        $this->deduplicateTemplates();
+        $this->deduplicateLayouts();
 
         Schema::table('renatio_dynamicpdf_pdf_templates', function (Blueprint $table) {
             $table->unique('code');
@@ -33,17 +34,38 @@ return new class extends Migration
     }
 
     /**
-     * Concurrent syncs could insert the same code twice; the customised (or locked) row
-     * wins, then the oldest, so nothing a user edited is lost.
+     * Concurrent syncs could insert the same code twice. The customised row wins, then the oldest.
      */
-    protected function deduplicate(string $table, string $keepFlag): void
+    protected function deduplicateTemplates(): void
     {
-        $duplicates = DB::table($table)->select('code')->groupBy('code')->havingRaw('COUNT(*) > 1')->pluck('code');
+        foreach ($this->duplicateCodes('renatio_dynamicpdf_pdf_templates') as $code) {
+            $keep = DB::table('renatio_dynamicpdf_pdf_templates')->where('code', $code)->orderByDesc('is_custom')->orderBy('id')->value('id');
 
-        foreach ($duplicates as $code) {
-            $keep = DB::table($table)->where('code', $code)->orderByDesc($keepFlag)->orderBy('id')->value('id');
-
-            DB::table($table)->where('code', $code)->where('id', '<>', $keep)->delete();
+            DB::table('renatio_dynamicpdf_pdf_templates')->where('code', $code)->where('id', '<>', $keep)->delete();
         }
+    }
+
+    /**
+     * The locked row wins, then the oldest; templates using a removed copy follow the kept one
+     * and the copies are deleted through the model so their attachments go with them.
+     */
+    protected function deduplicateLayouts(): void
+    {
+        foreach ($this->duplicateCodes('renatio_dynamicpdf_pdf_layouts') as $code) {
+            $keep = DB::table('renatio_dynamicpdf_pdf_layouts')->where('code', $code)->orderByDesc('is_locked')->orderBy('id')->value('id');
+            $losers = DB::table('renatio_dynamicpdf_pdf_layouts')->where('code', $code)->where('id', '<>', $keep)->pluck('id');
+
+            DB::table('renatio_dynamicpdf_pdf_templates')->whereIn('layout_id', $losers)->update(['layout_id' => $keep]);
+
+            Layout::whereIn('id', $losers)->get()->each->delete();
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function duplicateCodes(string $table): array
+    {
+        return DB::table($table)->groupBy('code')->havingRaw('COUNT(*) > 1')->pluck('code')->all();
     }
 };

--- a/updates/20260907_0002_add_unique_code_indexes.php
+++ b/updates/20260907_0002_add_unique_code_indexes.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $this->deduplicate('renatio_dynamicpdf_pdf_templates', 'is_custom');
+        $this->deduplicate('renatio_dynamicpdf_pdf_layouts', 'is_locked');
+
+        Schema::table('renatio_dynamicpdf_pdf_templates', function (Blueprint $table) {
+            $table->unique('code');
+        });
+
+        Schema::table('renatio_dynamicpdf_pdf_layouts', function (Blueprint $table) {
+            $table->unique('code');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('renatio_dynamicpdf_pdf_templates', function (Blueprint $table) {
+            $table->dropUnique(['code']);
+        });
+
+        Schema::table('renatio_dynamicpdf_pdf_layouts', function (Blueprint $table) {
+            $table->dropUnique(['code']);
+        });
+    }
+
+    /**
+     * Concurrent syncs could insert the same code twice; the customised (or locked) row
+     * wins, then the oldest, so nothing a user edited is lost.
+     */
+    protected function deduplicate(string $table, string $keepFlag): void
+    {
+        $duplicates = DB::table($table)->select('code')->groupBy('code')->havingRaw('COUNT(*) > 1')->pluck('code');
+
+        foreach ($duplicates as $code) {
+            $keep = DB::table($table)->where('code', $code)->orderByDesc($keepFlag)->orderBy('id')->value('id');
+
+            DB::table($table)->where('code', $code)->where('id', '<>', $keep)->delete();
+        }
+    }
+};

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -76,4 +76,6 @@ v8.0.4:
     - Add PDF::fake() with render assertions for project tests.
     - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
     - 20260907_0001_add_sample_data_to_templates_table.php
+    - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
+    - 20260907_0002_add_unique_code_indexes.php
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -76,6 +76,7 @@ v8.0.4:
     - Add PDF::fake() with render assertions for project tests.
     - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
     - 20260907_0001_add_sample_data_to_templates_table.php
+    - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.
+v8.0.5:
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
     - 20260907_0002_add_unique_code_indexes.php
-    - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.


### PR DESCRIPTION
## Problem
Kolumna `code` w tabelach szablonów i layoutów miała zwykły indeks, a synchronizacja zapisuje przez `forceSave()` (bez reguły `unique`). Dwie równoległe synchronizacje mogły wstawić duplikat; `byCode()` brał po cichu pierwszy, lista pokazywała dwa wiersze.

## Rozwiązanie
Migracja `20260907_0002_add_unique_code_indexes.php`: najpierw deduplikacja (zostaje wiersz `is_custom = 1` / `is_locked = 1`, w przeciwnym razie najstarszy), potem `unique('code')` na obu tabelach; `down()` zdejmuje indeksy. Wpis w UPGRADE.md 8.0.4 i `version.yaml`. Przegrany wyścig w `SyncTemplates::create()` trafia do istniejącego `catch (Throwable)` i jest logowany raz.

## Testy
`tests/Unit/Classes/ConcurrentSyncTest.php`: drugi zapis tego samego kodu szablonu rzuca `QueryException`, a wiersz zostaje jeden; duplikat kodu layoutu odrzucony na poziomie bazy.

Closes #149
