### PR TITLE
Migracja sample_data w wersji 8.0.5

### DIFF
--- a/updates/20260907_0001_add_sample_data_to_templates_table.php
+++ b/updates/20260907_0001_add_sample_data_to_templates_table.php
@@ -6,8 +6,16 @@ use October\Rain\Database\Updates\Migration;
 
 return new class extends Migration
 {
+    /**
+     * Guarded because the script shipped briefly under 8.0.4 before moving to 8.0.5, so an
+     * install that ran it there runs it again.
+     */
     public function up()
     {
+        if (Schema::hasColumn('renatio_dynamicpdf_pdf_templates', 'sample_data')) {
+            return;
+        }
+
         Schema::table('renatio_dynamicpdf_pdf_templates', function (Blueprint $table) {
             $table->text('sample_data')->nullable();
         });
@@ -15,6 +23,10 @@ return new class extends Migration
 
     public function down()
     {
+        if (! Schema::hasColumn('renatio_dynamicpdf_pdf_templates', 'sample_data')) {
+            return;
+        }
+
         Schema::table('renatio_dynamicpdf_pdf_templates', function (Blueprint $table) {
             $table->dropColumn('sample_data');
         });

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -74,9 +74,9 @@ v8.0.4:
     - Add toFile() and a chainable encrypt().
     - Add registerPDFVariables() and the beforeRender and afterRender events.
     - Add PDF::fake() with render assertions for project tests.
-    - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
-    - 20260907_0001_add_sample_data_to_templates_table.php
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.
 v8.0.5:
+    - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
+    - 20260907_0001_add_sample_data_to_templates_table.php
     - 20260907_0002_add_unique_code_indexes.php


### PR DESCRIPTION
Z review #162: skrypt dopisany do wersji już zapisanej w `system_plugin_versions` (8.0.4, także na dev DB) nigdy się nie uruchomi. Migracja `20260907_0001_add_sample_data_to_templates_table.php` i jej opis przechodzą do bloku `v8.0.5` razem z unikalnym indeksem. `version.yaml` zweryfikowany parserem YAML (same stringi/listy stringów).