### PR TITLE
Podgląd PDF: nazwa akcji lowercase (404 pod October 4.3.5)

### DIFF
--- a/controllers/Layouts.php
+++ b/controllers/Layouts.php
@@ -40,7 +40,7 @@ class Layouts extends Controller
         (new SyncTemplates)->handle();
     }
 
-    public function previewPdf(int|string $id): ?Response
+    public function previewpdf(int|string $id): ?Response
     {
         $this->pageTitle = e(trans('renatio.dynamicpdf::lang.templates.preview_pdf'));
 

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -68,7 +68,7 @@ class Templates extends Controller
         }
     }
 
-    public function previewPdf(int|string $id): ?Response
+    public function previewpdf(int|string $id): ?Response
     {
         $this->pageTitle = e(trans('renatio.dynamicpdf::lang.templates.preview_pdf'));
 

--- a/tests/Feature/PreviewActionTest.php
+++ b/tests/Feature/PreviewActionTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Renatio\DynamicPDF\Controllers\Layouts;
+use Renatio\DynamicPDF\Controllers\Templates;
+
+describe('Preview PDF action', function () {
+    it('is reachable from the lowercase URL October 4.3.5 requires', function () {
+        expect((new Templates)->actionExists('previewpdf'))->toBeTrue()
+            ->and((new Layouts)->actionExists('previewpdf'))->toBeTrue();
+    });
+});

--- a/tests/Feature/PreviewOptionsTest.php
+++ b/tests/Feature/PreviewOptionsTest.php
@@ -22,7 +22,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $template = $this->createTemplate(['content_html' => '<p>Hello</p>']);
 
-        (new Templates)->previewPdf($template->id);
+        (new Templates)->previewpdf($template->id);
 
         expect($wrapper->getDomPDF()->getOptions()->getIsPhpEnabled())->toBeFalse();
     });
@@ -31,7 +31,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
 
-        (new Layouts)->previewPdf($layout->id);
+        (new Layouts)->previewpdf($layout->id);
 
         expect($wrapper->getDomPDF()->getOptions()->getIsPhpEnabled())->toBeFalse();
     });
@@ -41,7 +41,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $template = $this->createTemplate(['content_html' => '<p>Hello</p>']);
 
-        (new Templates)->previewPdf($template->id);
+        (new Templates)->previewpdf($template->id);
 
         $options = $wrapper->getDomPDF()->getOptions();
 
@@ -57,7 +57,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
 
-        (new Layouts)->previewPdf($layout->id);
+        (new Layouts)->previewpdf($layout->id);
 
         expect($wrapper->getDomPDF()->getOptions()->getAllowedRemoteHosts())->toBe(['app.example.com']);
     });
@@ -67,7 +67,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
 
-        (new Layouts)->previewPdf($layout->id);
+        (new Layouts)->previewpdf($layout->id);
 
         expect($wrapper->getDomPDF()->getOptions()->getAllowedRemoteHosts())->toBe(['cdn.example.com', 'app.example.com']);
     });
@@ -76,7 +76,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $template = $this->createTemplate(['content_html' => '<p>Hello</p>']);
 
-        (new Templates)->previewPdf($template->id);
+        (new Templates)->previewpdf($template->id);
 
         expect(stream_context_get_options($wrapper->getDomPDF()->getHttpContext())['http']['follow_location'])->toBeFalse();
     });
@@ -85,7 +85,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $template = $this->createTemplate(['content_html' => '<p>Hello</p>']);
 
-        (new Templates)->previewPdf($template->id);
+        (new Templates)->previewpdf($template->id);
 
         $options = $wrapper->getDomPDF()->getOptions();
 
@@ -100,7 +100,7 @@ describe('Backend preview', function () {
         $wrapper = captureWrapper();
         $layout = $this->createLayout(['content_html' => '<html><body>Hello</body></html>']);
 
-        (new Layouts)->previewPdf($layout->id);
+        (new Layouts)->previewpdf($layout->id);
 
         expect($wrapper->getDomPDF()->getOptions()->getChroot())->toBe([storage_path('app')]);
     });

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -76,8 +76,8 @@ v8.0.4:
     - Add PDF::fake() with render assertions for project tests.
     - Render through the system Twig environment when the Cms module is missing or no theme is usable, and report CMS rendering errors instead of retrying with the system one.
 v8.0.5:
+    - Fix the 404 of the PDF preview under recent October 4.3 builds, which require lowercase action names.
     - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
     - 20260907_0001_add_sample_data_to_templates_table.php
-    - Fix the 404 of the PDF preview under October 4.3.5, whose action names must be lowercase.
     - 20260907_0002_add_unique_code_indexes.php

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -79,4 +79,5 @@ v8.0.5:
     - Backend previews render with the sample data of the template, lists show customised and locked records, templates and layouts can be duplicated and previewed from the list.
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
     - 20260907_0001_add_sample_data_to_templates_table.php
+    - Fix the 404 of the PDF preview under October 4.3.5, whose action names must be lowercase.
     - 20260907_0002_add_unique_code_indexes.php


### PR DESCRIPTION
## Problem
October 4.3.5 porównuje w `actionExists()` prawdziwą nazwę metody z segmentem URL-a; camelCase'owe `previewPdf()` stało się nieosiągalne z lowercase'owego linku `previewpdf/:id` (#113).

## Rozwiązanie
Metoda akcji w obu kontrolerach nazywa się `previewpdf()`; linki w partialach już takie były. Wpis w `version.yaml` (8.0.5).

## Testy
`tests/Feature/PreviewActionTest.php`: `actionExists('previewpdf')` dla obu kontrolerów – czerwony przed zmianą. Istniejące testy podglądu przełączone na nową nazwę.

Closes #113