### PR TITLE
Szablon z widoku nie staje się Customized po zapisie samych danych przykładowych (v8.0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .phpunit.cache/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ HTML to PDF converter uses [dompdf](https://github.com/dompdf/dompdf) library.
 
 Plugin uses dompdf wrapper for Laravel [barryvdh/laravel-dompdf](https://github.com/barryvdh/laravel-dompdf).
 
+## Features
+
+- PDF templates and layouts edited in the backend, with HTML and PDF preview rendered from sample data.
+- Templates and layouts registered by plugins as view files, synchronised to the database and customisable, with
+  reset to the file version.
+- Twig markup with theme partials, translations, global variables and `beforeRender` / `afterRender` events.
+- Render per document with another layout, in another language, with page numbers, password protection and
+  paper size and orientation.
+- Output as a browser stream, download, file on a storage disk or a `System\Models\File` ready to attach to a model.
+- `PDF::fake()` with render assertions for project tests, `dynamicpdf:sync` and `dynamicpdf:check` console commands.
+
 ## Requirements
 
 This plugin requires PHP 8.2 or higher and October CMS 4.0 or higher. Running its test suite and static analysis
@@ -329,8 +340,6 @@ wrapper for a single document. The setting applies to every wrapper instance, in
 |---------------------------------------------------------|----------------------------------------------------------|
 | loadTemplate($code, array $data = [], $encoding = null, $layout = null, $locale = null) | Load backend template, optionally with another layout and locale |
 | loadLayout($code, array $data = [], $encoding = null, $locale = null) | Load backend layout, optionally in another locale |
-| loadTemplate($code, array $data = [], $encoding = null, $layout = null) | Load backend template, optionally with another layout |
-| loadLayout($code, array $data = [], $encoding = null)   | Load backend layout                                      |
 | pageNumbers($text, $position, $size, $font, $margin, $color) | Stamp page numbers on every page                    |
 | allowSelfSignedCertificates()                           | Accept self-signed TLS certificates for remote resources |
 | loadHTML($string, $encoding = null)                     | Load HTML string                                         |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -94,6 +94,8 @@ The backend HTML and PDF preview no longer enables inline PHP. If you use the de
 
 ## Upgrading To 8.0.5
 
+Run `php artisan october:migrate`.
+
 The template and layout `code` columns get a unique index. Duplicate rows, which concurrent synchronisations could
 leave behind, are deleted permanently by the migration and not restored by a rollback: for templates the customised
 row is kept, for layouts the locked one, otherwise the oldest. Templates attached to a deleted layout are re-pointed

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -34,7 +34,7 @@ class PDF extends PdfFacade
         $app = static::getFacadeApplication() ?? throw new RuntimeException('Facade application has not been set.');
 
         $fake = new PDFFake($app->make('dompdf'), $app->make('config'), $app->make('files'), $app->make('view'));
-        $app->instance(static::getFacadeAccessor(), $fake);
+        static::swap($fake);
 
         return $fake;
     }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "barryvdh/laravel-dompdf": "^3.1"
     },
     "require-dev": {
+        "laravel/pao": "^1.1",
         "larastan/larastan": "^3.0",
         "pestphp/pest": "^5.0",
         "pestphp/pest-plugin-phpstan": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "rector/rector": "^2.0"
     },
     "scripts": {
+        "test": "../../../vendor/bin/pest -c phpunit.xml",
         "stan": "../../../vendor/bin/phpstan analyse --memory-limit=1G",
         "rector": "../../../vendor/bin/rector process --dry-run",
         "rector:fix": "../../../vendor/bin/rector process"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "rector/rector": "^2.0"
     },
     "scripts": {
-        "test": "../../../vendor/bin/pest -c phpunit.xml",
         "stan": "../../../vendor/bin/phpstan analyse --memory-limit=1G",
         "rector": "../../../vendor/bin/rector process --dry-run",
         "rector:fix": "../../../vendor/bin/rector process"

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -59,13 +59,30 @@ class Templates extends Controller
 
     /**
      * Only a change to what the view file provides detaches the template from the view;
-     * editing the sample data alone keeps it view-driven.
+     * editing the sample data alone keeps it view-driven. The posted values are compared
+     * with the model because the form data is applied to it only after this hook.
      */
     public function formBeforeSave(Template $model): void
     {
-        if ($model->isDirty(['title', 'description', 'content_html', 'layout_id', 'size', 'orientation'])) {
-            $model->is_custom = true;
+        if ($model->is_custom) {
+            return;
         }
+
+        $posted = $this->formGetWidget()->getSaveData();
+        $fields = ['title' => 'title', 'description' => 'description', 'content_html' => 'content_html', 'layout' => 'layout_id', 'size' => 'size', 'orientation' => 'orientation'];
+
+        foreach ($fields as $field => $attribute) {
+            if (array_key_exists($field, $posted) && $this->normalize($posted[$field]) !== $this->normalize($model->getAttribute($attribute))) {
+                $model->is_custom = true;
+
+                return;
+            }
+        }
+    }
+
+    protected function normalize(mixed $value): string
+    {
+        return str_replace("\r\n", "\n", trim((string) $value));
     }
 
     public function previewpdf(int|string $id): ?Response

--- a/controllers/Templates.php
+++ b/controllers/Templates.php
@@ -58,20 +58,26 @@ class Templates extends Controller
     }
 
     /**
-     * Only a change to what the view file provides detaches the template from the view;
-     * editing the sample data alone keeps it view-driven. The posted values are compared
-     * with the model because the form data is applied to it only after this hook.
+     * A template created in the backend is customised. A stored one is detached from its
+     * view only by a change to what the view file provides; editing the sample data alone
+     * keeps it view-driven. The posted values are compared with the model because the
+     * form data is applied to it only after this hook.
      */
     public function formBeforeSave(Template $model): void
     {
+        if (! $model->exists) {
+            $model->is_custom = true;
+
+            return;
+        }
+
         if ($model->is_custom) {
             return;
         }
 
-        $posted = $this->formGetWidget()->getSaveData();
-        $fields = ['title' => 'title', 'description' => 'description', 'content_html' => 'content_html', 'layout' => 'layout_id', 'size' => 'size', 'orientation' => 'orientation'];
+        $posted = (array) post($this->formGetWidget()->arrayName);
 
-        foreach ($fields as $field => $attribute) {
+        foreach (Template::VIEW_FIELDS as $field => $attribute) {
             if (array_key_exists($field, $posted) && $this->normalize($posted[$field]) !== $this->normalize($model->getAttribute($attribute))) {
                 $model->is_custom = true;
 

--- a/models/Template.php
+++ b/models/Template.php
@@ -36,6 +36,11 @@ class Template extends Model
 
     public const LAYOUT_CACHE = 'renatio.dynamicpdf.layouts';
 
+    /**
+     * Form fields the view file provides, mapped to the attribute they are stored in.
+     */
+    public const VIEW_FIELDS = ['title' => 'title', 'description' => 'description', 'content_html' => 'content_html', 'layout' => 'layout_id', 'size' => 'size', 'orientation' => 'orientation'];
+
     public $table = 'renatio_dynamicpdf_pdf_templates';
 
     /** @var array<string, string> */

--- a/models/Template.php
+++ b/models/Template.php
@@ -80,8 +80,7 @@ class Template extends Model
 
     /**
      * A stored, non-customised template follows its view file. The row is left as
-     * stored when the view is not registered any more or its file is missing. The
-     * refreshed attributes count as original, so only a later edit reads as dirty.
+     * stored when the view is not registered any more or its file is missing.
      */
     public function afterFetch(): void
     {
@@ -91,7 +90,6 @@ class Template extends Model
 
         try {
             $this->fillFromView($this->code);
-            $this->syncOriginal();
         } catch (Throwable $e) {
             Log::error("Renatio.DynamicPDF could not read the view of {$this->code}: {$e->getMessage()}", ['exception' => $e]);
         }

--- a/models/Template.php
+++ b/models/Template.php
@@ -80,7 +80,8 @@ class Template extends Model
 
     /**
      * A stored, non-customised template follows its view file. The row is left as
-     * stored when the view is not registered any more or its file is missing.
+     * stored when the view is not registered any more or its file is missing. The
+     * refreshed attributes count as original, so only a later edit reads as dirty.
      */
     public function afterFetch(): void
     {
@@ -90,6 +91,7 @@ class Template extends Model
 
         try {
             $this->fillFromView($this->code);
+            $this->syncOriginal();
         } catch (Throwable $e) {
             Log::error("Renatio.DynamicPDF could not read the view of {$this->code}: {$e->getMessage()}", ['exception' => $e]);
         }

--- a/tests/Feature/BackendPreviewToolsTest.php
+++ b/tests/Feature/BackendPreviewToolsTest.php
@@ -83,6 +83,12 @@ describe('View-driven template save', function () {
             ->and((string) $template->sample_data)->toBe('{"name": "Jane"}');
     });
 
+    it('is customised when created in the backend', function () {
+        $this->saveTemplateForm(null, ['title' => 'Made by hand', 'code' => 'viewdriven::pdf.b', 'content_html' => '<p>hand</p>'])->assertOk();
+
+        expect(Template::byCode('viewdriven::pdf.b')->is_custom)->toBeTrue();
+    });
+
     it('becomes customised when the content is edited in the form', function () {
         $this->saveTemplateForm($this->template->id, ['title' => 'a', 'content_html' => '<p>edited</p>'])->assertOk();
 

--- a/tests/Feature/BackendPreviewToolsTest.php
+++ b/tests/Feature/BackendPreviewToolsTest.php
@@ -1,7 +1,7 @@
 <?php
 
+use Backend\Facades\BackendAuth;
 use Illuminate\Support\Facades\File as Filesystem;
-use Illuminate\Support\Facades\View;
 use October\Rain\Exception\ValidationException;
 use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Controllers\Layouts;
@@ -53,20 +53,6 @@ describe('Backend preview tools', function () {
             ->and(File::where('attachment_id', $copy->id)->where('field', 'background_img')->count())->toBe(1);
     });
 
-    it('keeps a view-driven template view-driven when only the sample data changes', function () {
-        $template = $this->createTemplate(['is_custom' => false]);
-        $template->sample_data = '{"name": "Jane"}';
-
-        (new Templates)->formBeforeSave($template);
-
-        expect($template->is_custom)->toBeFalse();
-
-        $template->content_html = '<p>edited</p>';
-        (new Templates)->formBeforeSave($template);
-
-        expect($template->is_custom)->toBeTrue();
-    });
-
     it('links the layout list to the layout previews', function () {
         expect(file_get_contents(__DIR__ . '/../../models/layout/columns.yaml'))->toContain('path: column_preview_layout')
             ->and(file_get_contents(__DIR__ . '/../../controllers/templates/_column_preview_layout.php'))->toContain('renatio/dynamicpdf/layouts/preview/');
@@ -75,27 +61,34 @@ describe('Backend preview tools', function () {
 
 describe('View-driven template save', function () {
     beforeEach(function () {
-        $this->views = sys_get_temp_dir() . '/dynamicpdf-views-' . uniqid();
-        Filesystem::makeDirectory($this->views . '/pdf', 0755, true);
-        View::addNamespace('viewdriven', $this->views);
-        Filesystem::put($this->views . '/pdf/a.htm', "title = \"a\"\n==\n<p>v1</p>");
-        PDFManager::instance()->registerTemplates(['viewdriven::pdf.a']);
+        $this->views = $this->registerViewTemplates('viewdriven', ['a' => "title = \"a\"\n==\n<p>v1</p>"]);
+        $this->template = $this->createTemplate(['code' => 'viewdriven::pdf.a', 'is_custom' => false, 'content_html' => '<p>v1</p>', 'title' => 'a']);
+        actingAsBackendUserWith(['manage_templates']);
     });
 
     afterEach(function () {
+        BackendAuth::logout();
         PDFManager::forgetInstance();
         Filesystem::deleteDirectory($this->views);
     });
 
-    it('stays view-driven when only the sample data changes after the view file changed on disk', function () {
-        $this->createTemplate(['code' => 'viewdriven::pdf.a', 'is_custom' => false, 'content_html' => '<p>v1</p>', 'title' => 'a']);
+    it('stays view-driven when only the sample data is saved after the view file changed on disk', function () {
         Filesystem::put($this->views . '/pdf/a.htm', "title = \"a\"\n==\n<p>v2</p>");
 
-        $template = Template::byCode('viewdriven::pdf.a');
-        $template->sample_data = '{"name": "Jane"}';
-        (new Templates)->formBeforeSave($template);
+        $this->saveTemplateForm($this->template->id, ['title' => 'a', 'content_html' => '<p>v2</p>', 'sample_data' => '{"name": "Jane"}'])->assertOk();
 
-        expect((string) $template->content_html)->toBe('<p>v2</p>')
-            ->and($template->is_custom)->toBeFalse();
+        $template = Template::byCode('viewdriven::pdf.a');
+
+        expect($template->is_custom)->toBeFalse()
+            ->and((string) $template->sample_data)->toBe('{"name": "Jane"}');
+    });
+
+    it('becomes customised when the content is edited in the form', function () {
+        $this->saveTemplateForm($this->template->id, ['title' => 'a', 'content_html' => '<p>edited</p>'])->assertOk();
+
+        $template = Template::byCode('viewdriven::pdf.a');
+
+        expect($template->is_custom)->toBeTrue()
+            ->and((string) $template->content_html)->toBe('<p>edited</p>');
     });
 });

--- a/tests/Feature/BackendPreviewToolsTest.php
+++ b/tests/Feature/BackendPreviewToolsTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use Illuminate\Support\Facades\File as Filesystem;
+use Illuminate\Support\Facades\View;
 use October\Rain\Exception\ValidationException;
+use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Controllers\Layouts;
 use Renatio\DynamicPDF\Controllers\Templates;
 use Renatio\DynamicPDF\Models\Layout;
@@ -43,7 +46,7 @@ describe('Backend preview tools', function () {
 
         (new Layouts)->update_onDuplicate($layout->id);
         $copy = Layout::whereCode('acme::pdf.layouts.default_copy')->firstOrFail();
-        \Illuminate\Support\Facades\File::deleteDirectory($uploads);
+        Filesystem::deleteDirectory($uploads);
 
         expect($copy->getAttribute('is_locked'))->toBeFalsy()
             ->and((string) $copy->getAttribute('name'))->toBe('Test Layout (copy)')
@@ -67,5 +70,32 @@ describe('Backend preview tools', function () {
     it('links the layout list to the layout previews', function () {
         expect(file_get_contents(__DIR__ . '/../../models/layout/columns.yaml'))->toContain('path: column_preview_layout')
             ->and(file_get_contents(__DIR__ . '/../../controllers/templates/_column_preview_layout.php'))->toContain('renatio/dynamicpdf/layouts/preview/');
+    });
+});
+
+describe('View-driven template save', function () {
+    beforeEach(function () {
+        $this->views = sys_get_temp_dir() . '/dynamicpdf-views-' . uniqid();
+        Filesystem::makeDirectory($this->views . '/pdf', 0755, true);
+        View::addNamespace('viewdriven', $this->views);
+        Filesystem::put($this->views . '/pdf/a.htm', "title = \"a\"\n==\n<p>v1</p>");
+        PDFManager::instance()->registerTemplates(['viewdriven::pdf.a']);
+    });
+
+    afterEach(function () {
+        PDFManager::forgetInstance();
+        Filesystem::deleteDirectory($this->views);
+    });
+
+    it('stays view-driven when only the sample data changes after the view file changed on disk', function () {
+        $this->createTemplate(['code' => 'viewdriven::pdf.a', 'is_custom' => false, 'content_html' => '<p>v1</p>', 'title' => 'a']);
+        Filesystem::put($this->views . '/pdf/a.htm', "title = \"a\"\n==\n<p>v2</p>");
+
+        $template = Template::byCode('viewdriven::pdf.a');
+        $template->sample_data = '{"name": "Jane"}';
+        (new Templates)->formBeforeSave($template);
+
+        expect((string) $template->content_html)->toBe('<p>v2</p>')
+            ->and($template->is_custom)->toBeFalse();
     });
 });

--- a/tests/Feature/PermissionsTest.php
+++ b/tests/Feature/PermissionsTest.php
@@ -1,36 +1,8 @@
 <?php
 
 use Backend\Facades\BackendAuth;
-use Backend\Models\User;
 use Renatio\DynamicPDF\Controllers\Layouts;
 use Renatio\DynamicPDF\Controllers\Templates;
-
-/**
- * @param  array<int, string>  $permissions  codes without the plugin prefix
- */
-function actingAsBackendUserWith(array $permissions): User
-{
-    $granted = ['general.backend' => 1];
-
-    foreach ($permissions as $permission) {
-        $granted['renatio.dynamicpdf.' . $permission] = 1;
-    }
-
-    /** @var User $user */
-    $user = User::create([
-        'login' => 'permissions-' . uniqid(),
-        'email' => uniqid() . '@example.com',
-        'password' => 'Password!123456',
-        'password_confirmation' => 'Password!123456',
-        'first_name' => 'Permission',
-        'last_name' => 'Tests',
-        'permissions' => $granted,
-    ]);
-
-    BackendAuth::login($user);
-
-    return $user;
-}
 
 describe('Permissions', function () {
     afterEach(fn () => BackendAuth::logout());

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,8 +1,37 @@
 <?php
 
+use Backend\Facades\BackendAuth;
+use Backend\Models\User;
 use Renatio\DynamicPDF\Tests\TestCase;
 
 pest()->extend(TestCase::class)
     ->beforeEach(fn () => $this->setUpOctoberPlugin())
     ->afterEach(fn () => $this->tearDownOctoberPlugin())
     ->in(__DIR__);
+
+/**
+ * @param  array<int, string>  $permissions  codes without the plugin prefix
+ */
+function actingAsBackendUserWith(array $permissions): User
+{
+    $granted = ['general.backend' => 1];
+
+    foreach ($permissions as $permission) {
+        $granted['renatio.dynamicpdf.' . $permission] = 1;
+    }
+
+    /** @var User $user */
+    $user = User::create([
+        'login' => 'permissions-' . uniqid(),
+        'email' => uniqid() . '@example.com',
+        'password' => 'Password!123456',
+        'password_confirmation' => 'Password!123456',
+        'first_name' => 'Permission',
+        'last_name' => 'Tests',
+        'permissions' => $granted,
+    ]);
+
+    BackendAuth::login($user);
+
+    return $user;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,30 @@
 
 namespace Renatio\DynamicPDF\Tests;
 
+use Backend\Facades\Backend;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+use Illuminate\Testing\TestResponse;
+use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Models\Layout;
 use Renatio\DynamicPDF\Models\Template;
 
 abstract class TestCase extends OctoberPestTestCase
 {
+    /**
+     * Posts the update form of a template the way the backend does, through the onSave handler.
+     *
+     * @param  array<string, mixed>  $fields
+     * @return TestResponse<\Illuminate\Http\Response>
+     */
+    public function saveTemplateForm(int $id, array $fields): TestResponse
+    {
+        return $this->post(Backend::url('renatio/dynamicpdf/templates/update/' . $id), ['Template' => $fields], [
+            'X-AJAX-HANDLER' => 'onSave',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ]);
+    }
+
     /**
      * @param  array<string, mixed>  $attributes
      */
@@ -18,6 +37,27 @@ abstract class TestCase extends OctoberPestTestCase
             'content_html' => '<html><body>{{ content_html }}</body></html>',
             'content_css' => '',
         ], $attributes));
+    }
+
+    /**
+     * Registers PDF views written to a temporary directory under the given namespace and
+     * returns that directory; the caller deletes it and forgets the PDFManager instance.
+     *
+     * @param  array<string, string>  $files  view name without extension => file content
+     */
+    public function registerViewTemplates(string $namespace, array $files): string
+    {
+        $directory = sys_get_temp_dir() . '/dynamicpdf-views-' . uniqid();
+        File::makeDirectory($directory . '/pdf', 0755, true);
+        View::addNamespace($namespace, $directory);
+
+        foreach ($files as $name => $content) {
+            File::put("{$directory}/pdf/{$name}.htm", $content);
+        }
+
+        PDFManager::instance()->registerTemplates(array_map(fn (string $name): string => "{$namespace}::pdf.{$name}", array_keys($files)));
+
+        return $directory;
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,14 +13,14 @@ use Renatio\DynamicPDF\Models\Template;
 abstract class TestCase extends OctoberPestTestCase
 {
     /**
-     * Posts the update form of a template the way the backend does, through the onSave handler.
-     *
      * @param  array<string, mixed>  $fields
      * @return TestResponse<\Illuminate\Http\Response>
      */
-    public function saveTemplateForm(int $id, array $fields): TestResponse
+    public function saveTemplateForm(?int $id, array $fields): TestResponse
     {
-        return $this->post(Backend::url('renatio/dynamicpdf/templates/update/' . $id), ['Template' => $fields], [
+        $path = $id === null ? 'renatio/dynamicpdf/templates/create' : 'renatio/dynamicpdf/templates/update/' . $id;
+
+        return $this->post(Backend::url($path), ['Template' => $fields], [
             'X-AJAX-HANDLER' => 'onSave',
             'X-Requested-With' => 'XMLHttpRequest',
         ]);
@@ -40,8 +40,7 @@ abstract class TestCase extends OctoberPestTestCase
     }
 
     /**
-     * Registers PDF views written to a temporary directory under the given namespace and
-     * returns that directory; the caller deletes it and forgets the PDFManager instance.
+     * The caller deletes the returned directory and forgets the PDFManager instance.
      *
      * @param  array<string, string>  $files  view name without extension => file content
      */

--- a/tests/Unit/Classes/PDFFakeTest.php
+++ b/tests/Unit/Classes/PDFFakeTest.php
@@ -45,4 +45,12 @@ describe('PDF::fake()', function () {
         expect(fn () => $fake->assertNothingRendered())->toThrow(AssertionFailedError::class)
             ->and(fn () => $fake->assertRendered('acme::pdf.invoice', fn (array $data): bool => isset($data['missing'])))->toThrow(AssertionFailedError::class);
     });
+
+    it('replaces a wrapper the facade has already resolved', function () {
+        PDF::getFacadeRoot();
+
+        $fake = PDF::fake();
+
+        expect(PDF::getFacadeRoot())->toBe($fake);
+    });
 });

--- a/tests/Unit/Models/TemplateListQueriesTest.php
+++ b/tests/Unit/Models/TemplateListQueriesTest.php
@@ -2,21 +2,15 @@
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\View;
 use Renatio\DynamicPDF\Classes\PDFManager;
 use Renatio\DynamicPDF\Models\Template;
 
 describe('Template list queries', function () {
     beforeEach(function () {
-        $this->views = sys_get_temp_dir() . '/dynamicpdf-views-' . uniqid();
-        File::makeDirectory($this->views . '/pdf', 0755, true);
-        View::addNamespace('acmetest', $this->views);
-
-        foreach (['a', 'b', 'c'] as $name) {
-            File::put($this->views . "/pdf/{$name}.htm", "title = \"{$name}\"\nlayout = \"acme::pdf.layouts.default\"\n==\n<p>{$name}</p>");
-        }
-
-        PDFManager::instance()->registerTemplates(['acmetest::pdf.a', 'acmetest::pdf.b', 'acmetest::pdf.c']);
+        $this->views = $this->registerViewTemplates('acmetest', array_combine(['a', 'b', 'c'], array_map(
+            fn (string $name): string => "title = \"{$name}\"\nlayout = \"acme::pdf.layouts.default\"\n==\n<p>{$name}</p>",
+            ['a', 'b', 'c'],
+        )));
     });
 
     afterEach(function () {

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -81,6 +81,4 @@ v8.0.5:
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
     - 20260907_0001_add_sample_data_to_templates_table.php
     - 20260907_0002_add_unique_code_indexes.php
-v8.0.6:
-    - Fix the backend form never marking an edited view-driven template as customised, and marking it customised when only the sample data was saved.
-    - PDF::fake() replaces a wrapper the facade has already resolved.
+v8.0.6: Fix the customised flag on view-driven templates in the backend form, and PDF::fake() when the facade is already resolved.

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -82,5 +82,5 @@ v8.0.5:
     - 20260907_0001_add_sample_data_to_templates_table.php
     - 20260907_0002_add_unique_code_indexes.php
 v8.0.6:
-    - Fix a view-driven template becoming customised when only its sample data is saved after the view file changed.
+    - Fix the backend form never marking an edited view-driven template as customised, and marking it customised when only the sample data was saved.
     - PDF::fake() replaces a wrapper the facade has already resolved.

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -81,3 +81,6 @@ v8.0.5:
     - Add a unique index on the template and layout code, removing duplicates left by concurrent syncs.
     - 20260907_0001_add_sample_data_to_templates_table.php
     - 20260907_0002_add_unique_code_indexes.php
+v8.0.6:
+    - Fix a view-driven template becoming customised when only its sample data is saved after the view file changed.
+    - PDF::fake() replaces a wrapper the facade has already resolved.


### PR DESCRIPTION
## Opis

Dwa błędy w oznaczaniu szablonu jako *Customized* przy zapisie z panelu:

1. `Templates::formBeforeSave()` z #161 sprawdzało `isDirty()`, ale `FormController::update_onSave()` woła ten hook **przed** wypełnieniem modelu danymi z formularza. Edycja treści szablonu z widoku nigdy więc nie ustawiała `is_custom`, a zapisany wiersz był przy następnym odczycie nadpisywany treścią z pliku widoku.
2. Odwrotnie: gdy plik widoku zmienił się na dysku od synchronizacji, `afterFetch()` odświeżał atrybuty i przez to były „dirty” jeszcze przed edycją, więc zapis samego pola *Sample data* oznaczał szablon jako *Customized*.

Hook porównuje teraz wartości wysłane przez formularz (`formGetWidget()->getSaveData()`) z modelem; różnica w tytule, opisie, treści, layoucie, rozmiarze lub orientacji odpina szablon od widoku, zmiana samych danych przykładowych nie. Model nie jest zmieniany, więc *Reset to default* i synchronizacja działają jak dotąd.

## Pozostałe zmiany

- `PDF::fake()` używa `static::swap()`: dotąd fasada rozwiązana wcześniej w teście dalej wskazywała prawdziwy wrapper (test `replaces a wrapper the facade has already resolved` pada na starym kodzie).
- Testy regresyjne przechodzą przez prawdziwy handler `onSave` (`saveTemplateForm()` w `TestCase`); fixture widoków (`registerViewTemplates()`) i helper użytkownika panelu przeniesione do wspólnych plików, żeby `TemplateListQueriesTest` i nowe testy nie dublowały scaffoldingu.
- README: usunięte zdublowane wiersze `loadTemplate` / `loadLayout` w tabeli metod, dodana sekcja *Features* jak w pozostałych pluginach.
- UPGRADE: krok `october:migrate` przy 8.0.5.
- `version.yaml`: wpis v8.0.6, `.gitignore`: `.DS_Store`.

## Testy

- Nowe testy `stays view-driven when only the sample data is saved…` i `becomes customised when the content is edited in the form` padają na kodzie z master, przechodzą z poprawką.
- 99 testów, PHPStan level 7 i Pint bez uwag (PHP 8.4).